### PR TITLE
[WIP] Tests for pytest.param in parametrize

### DIFF
--- a/pytest_cases/tests/fixtures/param/test_id_param_in_parametrize_plus.py
+++ b/pytest_cases/tests/fixtures/param/test_id_param_in_parametrize_plus.py
@@ -1,0 +1,52 @@
+"""
+Copy of test_fixture_in_parametrize.py to test using of pytest.param for marking tests with id in parametrize_plus
+
+Showcased bugs:
+    * id is applied even on the second fixture if it doesnt override it (fixture_ref(a))
+    * fixture_ref is not translated to an actual fixture value
+"""
+import pytest
+
+from pytest_cases import fixture_ref, parametrize_plus, fixture_plus
+
+
+@pytest.fixture
+def a():
+    return 'a'
+
+
+@fixture_plus
+@parametrize_plus('second_letter', [fixture_ref('a'),
+                                    'o'])
+def b(second_letter):
+    # second_letter = 'a'
+    return 'b' + second_letter
+
+
+@parametrize_plus('arg', [pytest.param('z', id="id-z"),
+                          fixture_ref(a),
+                          pytest.param(fixture_ref(b), id="id-b"),
+                          pytest.param('o', id="id-o")])
+@pytest.mark.parametrize('bar', ['bar'])
+def test_foo(arg, bar):
+    assert bar == 'bar'
+    assert arg in ['z',
+                   'a',
+                   'ba',
+                   'bo',
+                   'o']
+
+
+def test_synthesis(module_results_dct):
+    """This is the actual result
+    ['test_foo[arg_is_0-id-z-id-b-bar]',
+     'test_foo[arg_is_0-id-z-id-o-bar]',
+     'test_foo[arg_is_a-id-z-id-b-bar]',
+     'test_foo[arg_is_a-id-z-id-o-bar]',
+     'test_foo[arg_is_2to3-id-z-id-b-bar]',
+     'test_foo[arg_is_2to3-id-z-id-o-bar]']"""
+    assert list(module_results_dct) == ['test_foo[arg_is_0-idz-bar]',
+                                        'test_foo[arg_is_a-bar]',
+                                        'test_foo[arg_is_b-second_letter_is_a-bar]',
+                                        'test_foo[arg_is_b-second_letter_is_1-o-bar]',
+                                        'test_foo[arg_is_3-o-bar]']

--- a/pytest_cases/tests/fixtures/param/test_mark_param_in_parametrize.py
+++ b/pytest_cases/tests/fixtures/param/test_mark_param_in_parametrize.py
@@ -1,0 +1,23 @@
+"""
+Simplified version of test_mark_param_in_parametrize.py to showcase how normal parametrize acts
+"""
+import pytest
+
+from pytest_cases import fixture_ref, parametrize_plus, fixture_plus
+
+
+@pytest.mark.parametrize('arg', [pytest.param('z', marks=pytest.mark.skipif("5>4")),
+                                 'a',
+                                 'b',
+                                 pytest.param('o', marks=pytest.mark.skipif("4>5"))])
+@pytest.mark.parametrize('bar', ['bar'])
+def test_foo(arg, bar):
+    assert bar == 'bar'
+    assert arg in ['z',
+                   'a',
+                   'b',
+                   'o']
+
+
+def test_synthesis(module_results_dct):
+    assert list(module_results_dct) == ['test_foo[bar-a]', 'test_foo[bar-b]', 'test_foo[bar-o]']

--- a/pytest_cases/tests/fixtures/param/test_mark_param_in_parametrize_plus.py
+++ b/pytest_cases/tests/fixtures/param/test_mark_param_in_parametrize_plus.py
@@ -1,0 +1,46 @@
+"""
+Copy of test_fixture_in_parametrize.py to test using of pytest.param for adding additional marks in parametrize_plus
+
+Bugs:
+   * Skipif is applied to all values even if should be applied to only the first case
+   * Second skipif is ignored (maybe because of the first problem)
+"""
+import pytest
+
+from pytest_cases import fixture_ref, parametrize_plus, fixture_plus
+
+
+@pytest.fixture
+def a():
+    return 'a'
+
+
+@fixture_plus
+@parametrize_plus('second_letter', [fixture_ref('a'),
+                                    pytest.param('o', marks=pytest.mark.skipif("4>5"))])
+def b(second_letter):
+    # second_letter = 'a'
+    return 'b' + second_letter
+
+
+@parametrize_plus('arg', [pytest.param('z', marks=pytest.mark.skipif("5>4")),
+                          fixture_ref(a),
+                          fixture_ref(b),
+                          'o'])
+@pytest.mark.parametrize('bar', ['bar'])
+def test_foo(arg, bar):
+    assert bar == 'bar'
+    assert arg in ['z',
+                   'a',
+                   'ba',
+                   'bo',
+                   'o']
+
+
+def test_synthesis(module_results_dct):
+    """This is the actual result []"""
+    assert list(module_results_dct) == ['test_foo[arg_is_0-idz-bar]',
+                                        'test_foo[arg_is_a-bar]',
+                                        'test_foo[arg_is_b-second_letter_is_a-bar]',
+                                        'test_foo[arg_is_b-second_letter_is_1-o-bar]',
+                                        'test_foo[arg_is_3-o-bar]']


### PR DESCRIPTION
Proof of concept of tests for #79 that use `pytest.param` inside of `parametrize_plus`. As can be seen in the tests, `parametrize_plus` doesn't properly work with it.

Bugs:
  * Marks and ids are applied to all cases on only the one that contains them.
  * `fixture_ref` is not translated to an actual fixture value

Note: these tests are really a quick proof of concept just to showcase a few bugs, I will rewrite them properly after the issues are solved.
