### PR TITLE
Fixed issues 85 (`fixture_union` when using the same fixture twice in it) and 87 (`ids` precedence order when using `pytest.mark.parametrize` in a `fixture_plus`)

### DIFF
--- a/ci_tools/generate-junit-badge.py
+++ b/ci_tools/generate-junit-badge.py
@@ -1,4 +1,6 @@
 import sys
+from math import floor
+
 try:
     # python 3
     from urllib.parse import quote_plus
@@ -34,7 +36,7 @@ def get_test_stats(junit_xml='reports/junit/junit.xml'  # type: str
     failed = len(tr.failures)
     success = runned - failed
 
-    success_percentage = round(success * 100 / runned)
+    success_percentage = floor(success * 100 / runned)
 
     return TestStats(success_percentage, success, runned, skipped)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### 1.13.2 - in progress - bugfixes and hook feature
+### 1.14.0 - bugfixes and hook feature
+
+ - Fixed `ids` precedence order when using `pytest.mark.parametrize` in a `fixture_plus`. Fixed [#87](https://github.com/smarie/python-pytest-cases/issues/87)
+
+ - Fixed issue with `fixture_union` when using the same fixture twice in it. Fixes [#85](https://github.com/smarie/python-pytest-cases/issues/85)
 
  - Added the possibility to pass a `hook` function in all API where fixtures are created behind the scenes, so as to ease debugging and/or save fixtures (with `stored_fixture` from pytest harvest). Fixes [#83](https://github.com/smarie/python-pytest-cases/issues/83)
  

--- a/pytest_cases/common.py
+++ b/pytest_cases/common.py
@@ -259,6 +259,18 @@ def get_parametrize_signature():
 
 
 # ---------- test ids utils ---------
+def combine_ids(paramid_tuples):
+    """
+    Receives a list of tuples containing ids for each parameterset.
+    Returns the final ids, that are obtained by joining the various param ids by '-' for each test node
+
+    :param paramid_tuples:
+    :return:
+    """
+    #
+    return ['-'.join(pid for pid in testid) for testid in paramid_tuples]
+
+
 def get_test_ids_from_param_values(param_names,
                                    param_values,
                                    ):
@@ -285,43 +297,81 @@ def get_test_ids_from_param_values(param_names,
 
 
 # ---- ParameterSet api ---
-def extract_parameterset_info(pnames, pmark):
+def analyze_parameter_set(pmark=None, argnames=None, argvalues=None, ids=None):
+    """
+    analyzes a parameter set passed either as a pmark or as distinct
+    (argnames, argvalues, ids) to extract/construct the various ids, marks, and
+    values
+
+    :return: ids, marks, values
+    """
+    if pmark is not None:
+        if any(a is not None for a in (argnames, argvalues, ids)):
+            raise ValueError("Either provide a pmark OR the details")
+        argnames = pmark.param_names
+        argvalues = pmark.param_values
+        ids = pmark.param_ids
+
+    # extract all parameters that have a specific configuration (pytest.param())
+    custom_pids, p_marks, p_values = extract_parameterset_info(argnames, argvalues)
+
+    # Create the proper id for each test
+    if ids is not None:
+        # overridden at global pytest.mark.parametrize level - this takes precedence.
+        try:  # an explicit list of ids ?
+            p_ids = list(ids)
+        except TypeError:  # a callable to apply on the values
+            p_ids = list(ids(v) for v in p_values)
+    else:
+        # default: values-based
+        p_ids = get_test_ids_from_param_values(argnames, p_values)
+
+    # Finally, local pytest.param takes precedence over everything else
+    for i, _id in enumerate(custom_pids):
+        if _id is not None:
+            p_ids[i] = _id
+
+    return p_ids, p_marks, p_values
+
+
+def extract_parameterset_info(argnames, argvalues):
     """
 
-    :param pnames: the names in this parameterset
-    :param pmark: the parametrization mark (a _ParametrizationMark)
+    :param argnames: the names in this parameterset
+    :param argvalues: the values in this parameterset
     :return:
     """
-    _pids = []
-    _pmarks = []
-    _pvalues = []
-    for v in pmark.param_values:
+    pids = []
+    pmarks = []
+    pvalues = []
+    for v in argvalues:
         if is_marked_parameter_value(v):
             # --id
             id = get_marked_parameter_id(v)
-            _pids.append(id)
+            pids.append(id)
             # --marks
             marks = get_marked_parameter_marks(v)
-            _pmarks.append(marks)  # note: there might be several
+            pmarks.append(marks)  # note: there might be several
             # --value(a tuple if this is a tuple parameter)
             vals = get_marked_parameter_values(v)
-            if len(vals) != len(pnames):
+            if len(vals) != len(argnames):
                 raise ValueError("Internal error - unsupported pytest parametrization+mark combination. Please "
                                  "report this issue")
             if len(vals) == 1:
-                _pvalues.append(vals[0])
+                pvalues.append(vals[0])
             else:
-                _pvalues.append(vals)
+                pvalues.append(vals)
         else:
-            _pids.append(None)
-            _pmarks.append(None)
-            _pvalues.append(v)
+            pids.append(None)
+            pmarks.append(None)
+            pvalues.append(v)
 
-    return _pids, _pmarks, _pvalues
+    return pids, pmarks, pvalues
 
 
 try:  # pytest 3.x+
     from _pytest.mark import ParameterSet
+
     def is_marked_parameter_value(v):
         return isinstance(v, ParameterSet)
 

--- a/pytest_cases/common.py
+++ b/pytest_cases/common.py
@@ -232,12 +232,15 @@ def get_pytest_parametrize_marks(f):
             # mark_info.args contains a list of (name, values)
             if len(mark_info.args) % 2 != 0:
                 raise ValueError("internal pytest compatibility error - please report")
-            nb_parameters = len(mark_info.args) // 2
-            if nb_parameters > 1 and len(mark_info.kwargs) > 0:
+            nb_parametrize_decorations = len(mark_info.args) // 2
+            if nb_parametrize_decorations > 1 and len(mark_info.kwargs) > 0:
                 raise ValueError("Unfortunately with this old pytest version it is not possible to have several "
-                                 "parametrization decorators")
+                                 "parametrization decorators while specifying **kwargs, as all **kwargs are "
+                                 "merged, leading to inconsistent results. Either upgrade pytest, remove the **kwargs,"
+                                 "or merge all the @parametrize decorators into a single one. **kwargs: %s"
+                                 % mark_info.kwargs)
             res = []
-            for i in range(nb_parameters):
+            for i in range(nb_parametrize_decorations):
                 param_name, param_values = mark_info.args[2*i:2*(i+1)]
                 res.append(_ParametrizationMark(_LegacyMark(param_name, param_values, **mark_info.kwargs)))
             return tuple(res)

--- a/pytest_cases/main_fixtures.py
+++ b/pytest_cases/main_fixtures.py
@@ -972,9 +972,17 @@ def _fixture_union(caller_module,
     if len(f_names) < 1:
         raise ValueError("Empty fixture unions are not permitted")
 
+    # remove duplicates in the fixture arguments
+    f_names_args = []
+    for _fname in f_names:
+        if _fname in f_names_args:
+            warn("Creating a fixture union %r where two alternatives are the same fixture %r." % (name, _fname))
+        else:
+            f_names_args.append(_fname)
+
     # then generate the body of our union fixture. It will require all of its dependent fixtures and receive as
     # a parameter the name of the fixture to use
-    @with_signature("%s(%s, request)" % (name, ', '.join(f_names)))
+    @with_signature("%s(%s, request)" % (name, ', '.join(f_names_args)))
     def _new_fixture(request, **all_fixtures):
         if not is_used_request(request):
             return NOT_USED

--- a/pytest_cases/plugin.py
+++ b/pytest_cases/plugin.py
@@ -982,8 +982,11 @@ class CallsReactor:
                                                     ids=p_to_apply.ids,
                                                     scope=p_to_apply.scope, **p_to_apply.kwargs)
 
-                    # Change the ids
+                    # Change the ids by applying the style defined in the corresponding alternative
                     for callspec in calls:
+                        # TODO right now only the idstyle defined in the first alternative is used. But it cant be
+                        #  different from the other ones for now because of the way fixture_union is built.
+                        #  Maybe the best would be to remove this and apply the id style when fixture is created.
                         callspec._idlist[-1] = apply_id_style(callspec._idlist[-1],
                                                               p_to_apply.union_fixture_name,
                                                               p_to_apply.alternative_names[0].idstyle)

--- a/pytest_cases/tests/fixtures/test_fixtures_parametrize.py
+++ b/pytest_cases/tests/fixtures/test_fixtures_parametrize.py
@@ -27,12 +27,22 @@ def test_synthesis(module_results_dct):
 
 
 # pytest.param - not available in all versions
-if LooseVersion(pytest.__version__) >= LooseVersion('3.0.0'):
+if LooseVersion(pytest.__version__) < LooseVersion('3.2.0'):
     # with pytest < 3.2.0 we
     # - would have to merge all parametrize marks if we wish to pass a kwarg (here, ids)
     # - cannot use pytest.param as it is not taken into account
     # > no go
 
+    def test_warning_pytest2():
+        with pytest.raises(ValueError) as exc_info:
+            @pytest_fixture_plus
+            @pytest.mark.parametrize("arg2", [0], ids=str)
+            @pytest.mark.parametrize("arg1", [1])
+            def a(arg1, arg2):
+                return arg1, arg2
+        assert "Unfortunately with this old pytest version it" in str(exc_info.value)
+
+else:
     @pytest_fixture_plus
     @pytest.mark.parametrize("arg3", [pytest.param(0, id='!0!')], ids=str)
     @pytest.mark.parametrize("arg1, arg2", [

--- a/pytest_cases/tests/fixtures/test_fixtures_parametrize.py
+++ b/pytest_cases/tests/fixtures/test_fixtures_parametrize.py
@@ -25,30 +25,31 @@ def test_one(myfix):
 
 
 @pytest_fixture_plus
+@pytest.mark.parametrize("arg3", [pytest_param(0, id='!0!')], ids=str)
 @pytest.mark.parametrize("arg1, arg2", [
     (1, 2),
     pytest_param(3, 4, id="p_a"),
     pytest_param(5, 6, id="skipped", marks=pytest.mark.skip)
 ])
-def myfix2(arg1, arg2):
-    return arg1, arg2
+def myfix2(arg1, arg2, arg3):
+    return arg1, arg2, arg3
 
 
 def test_two(myfix2):
-    assert myfix2 in {(1, 2), (3, 4), (5, 6)}
+    assert myfix2 in {(1, 2, 0), (3, 4, 0), (5, 6, 0)}
     print(myfix2)
 
 
 @pytest_fixture_plus
 @pytest.mark.parametrize("arg1, arg2", [
-    pytest_param(5, 6, id="ignored_id")
-], ids=['a'])
+    pytest_param(5, 6, id="a")
+], ids=['ignored_id'])
 def myfix3(arg1, arg2):
     return arg1, arg2
 
 
 def test_two(myfix2, myfix3):
-    assert myfix2 in {(1, 2), (3, 4), (5, 6)}
+    assert myfix2 in {(1, 2, 0), (3, 4, 0), (5, 6, 0)}
     print(myfix2)
 
 

--- a/pytest_cases/tests/fixtures/test_fixtures_parametrize.py
+++ b/pytest_cases/tests/fixtures/test_fixtures_parametrize.py
@@ -67,6 +67,6 @@ def test_synthesis(module_results_dct):
                                         'test_one[one-two]',
                                         'test_one[two-one]',
                                         'test_one[two-two]',
-                                        'test_two[1-2-a]',
-                                        'test_two[%s-a]' % id_of_last_tests[0],
+                                        'test_two[1-2-!0!-a]',
+                                        'test_two[%s-!0!-a]' % id_of_last_tests[0],
                                         ] + extra_test

--- a/pytest_cases/tests/fixtures/test_issue_github_54.py
+++ b/pytest_cases/tests/fixtures/test_issue_github_54.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pytest_cases.main_fixtures import InvalidParamsList
-from pytest_cases import pytest_parametrize_plus, fixture_ref
+from pytest_cases import parametrize_plus, fixture_ref
 
 
 @pytest.fixture
@@ -11,6 +11,6 @@ def test():
 
 def test_invalid_argvalues():
     with pytest.raises(InvalidParamsList):
-        @pytest_parametrize_plus('main_msg', fixture_ref(test))
+        @parametrize_plus('main_msg', fixture_ref(test))
         def test_prints(main_msg):
             print(main_msg)

--- a/pytest_cases/tests/issues/test_issue_fixture_union1.py
+++ b/pytest_cases/tests/issues/test_issue_fixture_union1.py
@@ -15,6 +15,4 @@ def test_foo(u):
 
 
 def test_synthesis(module_results_dct):
-    assert list(module_results_dct) == [
-
-    ]
+    assert list(module_results_dct) == ['test_foo[u_is_a0]', 'test_foo[u_is_a1]']

--- a/pytest_cases/tests/issues/test_issue_fixture_union1.py
+++ b/pytest_cases/tests/issues/test_issue_fixture_union1.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest_cases import fixture_union
+
+
+@pytest.fixture
+def a():
+    return 1
+
+
+u = fixture_union("u", (a, a))
+
+
+def test_foo(u):
+    pass
+
+
+def test_synthesis(module_results_dct):
+    assert list(module_results_dct) == [
+
+    ]

--- a/pytest_cases/tests/issues/test_issue_fixture_union1.py
+++ b/pytest_cases/tests/issues/test_issue_fixture_union1.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import pytest
 from pytest_cases import fixture_union
 
@@ -15,4 +17,8 @@ def test_foo(u):
 
 
 def test_synthesis(module_results_dct):
-    assert list(module_results_dct) == ['test_foo[u_is_a0]', 'test_foo[u_is_a1]']
+    if LooseVersion(pytest.__version__) < LooseVersion('3.0.0'):
+        # the way to make ids uniques in case of duplicates was different in old pytest
+        assert list(module_results_dct) == ['test_foo[u_is_0a]', 'test_foo[u_is_1a]']
+    else:
+        assert list(module_results_dct) == ['test_foo[u_is_a0]', 'test_foo[u_is_a1]']


### PR DESCRIPTION
Fixes #85 
Fixes #87 
