### PR TITLE
New features for `lazy_value` + removed annoying warning

### DIFF
--- a/pytest_cases/common_pytest.py
+++ b/pytest_cases/common_pytest.py
@@ -473,12 +473,18 @@ except ImportError:  # pytest 2.x
         """ Dummy function (not a class) used only by parametrize_plus """
         if id is not None:
             raise ValueError("This should not happen as `pytest.param` does not exist in pytest 2")
-        for m in marks:
-            values = pytest.mark()
-            raise ValueError("TODO")
 
         # smart unpack is required for compatibility
-        return values[0] if len(values) == 1 else values
+        val = values[0] if len(values) == 1 else values
+        nbmarks = len(marks)
+
+        if nbmarks == 0:
+            return val
+        elif nbmarks > 1:
+            raise ValueError("Multiple marks on parameters not supported for old versions of pytest")
+        else:
+            # decorate with the MarkDecorator
+            return marks[0](val)
 
     def is_marked_parameter_value(v):
         return isinstance(v, MarkDecorator)

--- a/pytest_cases/tests/pytest_extension/parametrize_plus/test_lazy_value.py
+++ b/pytest_cases/tests/pytest_extension/parametrize_plus/test_lazy_value.py
@@ -3,17 +3,25 @@ import pytest
 from pytest_cases import parametrize_plus, lazy_value
 
 
+has_pytest_param = hasattr(pytest, 'param')
+
+
 def valtuple():
     return 1, 2
+
+
+@pytest.mark.skipif(not has_pytest_param, reason="well")
+def val_skipped_on_old_pytest():
+    return "what"
 
 
 def val():
     return 1
 
 
-has_pytest_param = hasattr(pytest, 'param')
 if not has_pytest_param:
     @parametrize_plus("a", [lazy_value(val),
+                            lazy_value(val_skipped_on_old_pytest),
                             lazy_value(val, id='A')])
     def test_foo_single(a):
         """here the fixture is used for both parameters at the same time"""
@@ -37,6 +45,7 @@ if not has_pytest_param:
 
 else:
     @parametrize_plus("a", [lazy_value(val),
+                            pytest.param(lazy_value(val_skipped_on_old_pytest), marks=pytest.mark.skip),
                             pytest.param(lazy_value(val), id='B'),
                             pytest.param(lazy_value(val, id='ignored'), id='C'),
                             lazy_value(val, id='A')])

--- a/pytest_cases/tests/pytest_extension/parametrize_plus/test_lazy_value_so.py
+++ b/pytest_cases/tests/pytest_extension/parametrize_plus/test_lazy_value_so.py
@@ -1,0 +1,31 @@
+from functools import partial
+from random import random
+
+import pytest
+
+from pytest_cases import lazy_value
+
+
+database = [random() for i in range(10)]
+
+
+def get_param(i):
+    return database[i]
+
+
+def make_param_getter(i, use_partial=True):
+    if use_partial:
+        return partial(get_param, i)
+    else:
+        def _get_param():
+            return database[i]
+
+        return _get_param
+
+
+many_parameters = (make_param_getter(i) for i in range(10))
+
+
+@pytest.mark.parametrize('a', [lazy_value(f) for f in many_parameters])
+def test_foo(a):
+    print(a)


### PR DESCRIPTION
 - A function used as a `lazy_value` can now be marked with pytest marks. Fixes #99
 - A `lazy_value` now has a nicer id when it is a partial. Fixes #97 
 - Removed annoying `PytestUnknownMarkWarning` warning message when a mark was used on a case. Fixes #100
