### PR TITLE
parametrize_with_cases can get argnames as list

### DIFF
--- a/pytest_cases/case_parametrizer_new.py
+++ b/pytest_cases/case_parametrizer_new.py
@@ -39,7 +39,7 @@ except:  # noqa
     pass
 
 
-def parametrize_with_cases(argnames,                # type: str
+def parametrize_with_cases(argnames,                # type: Union[str, List[str]]
                            cases=AUTO,              # type: Union[Callable, Type, ModuleRef]
                            prefix=CASE_PREFIX_FUN,  # type: str
                            glob=None,               # type: str

--- a/pytest_cases/case_parametrizer_new.py
+++ b/pytest_cases/case_parametrizer_new.py
@@ -39,7 +39,7 @@ except:  # noqa
     pass
 
 
-def parametrize_with_cases(argnames,                # type: Union[str, List[str]]
+def parametrize_with_cases(argnames,                # type: Union[str, List[str], Tuple[str, ...]]
                            cases=AUTO,              # type: Union[Callable, Type, ModuleRef]
                            prefix=CASE_PREFIX_FUN,  # type: str
                            glob=None,               # type: str

--- a/pytest_cases/fixture_parametrize_plus.py
+++ b/pytest_cases/fixture_parametrize_plus.py
@@ -810,7 +810,7 @@ def _get_argnames_argvalues(argnames=None, argvalues=None, **args):
         raise TypeError("argnames should be a string, list or a tuple")
 
     if any([not isinstance(argname, str) for argname in argnames]):
-        raise TypeError("all argnames should be a strings")
+        raise TypeError("all argnames should be strings")
 
     if argvalues is None:
         raise ValueError("No argvalues provided while argnames are provided")

--- a/pytest_cases/fixture_parametrize_plus.py
+++ b/pytest_cases/fixture_parametrize_plus.py
@@ -802,9 +802,15 @@ def _get_argnames_argvalues(argnames=None, argvalues=None, **args):
             argvalues = [l[0] if not is_marked_parameter_value(l) else l for l in argvalues]
         return argnames, argvalues
 
-    elif isinstance(argnames, string_types):
+    if isinstance(argnames, string_types):
         # (2) argnames + argvalues, as usual. However **args can also be passed and should be added
         argnames = get_param_argnames_as_list(argnames)
+
+    if not isinstance(argnames, (list, tuple)):
+        raise TypeError("argnames should be a string, list or a tuple")
+
+    if any([not isinstance(argname, str) for argname in argnames]):
+        raise TypeError("all argnames should be a strings")
 
     if argvalues is None:
         raise ValueError("No argvalues provided while argnames are provided")

--- a/pytest_cases/fixture_parametrize_plus.py
+++ b/pytest_cases/fixture_parametrize_plus.py
@@ -800,24 +800,25 @@ def _get_argnames_argvalues(argnames=None, argvalues=None, **args):
         # simplify if needed to comply with pytest.mark.parametrize
         if len(argnames) == 1:
             argvalues = [l[0] if not is_marked_parameter_value(l) else l for l in argvalues]
+        return argnames, argvalues
 
     elif isinstance(argnames, string_types):
         # (2) argnames + argvalues, as usual. However **args can also be passed and should be added
         argnames = get_param_argnames_as_list(argnames)
 
-        if argvalues is None:
-            raise ValueError("No argvalues provided while argnames are provided")
+    if argvalues is None:
+        raise ValueError("No argvalues provided while argnames are provided")
 
-        # transform argvalues to a list (it can be a generator)
-        try:
-            argvalues = list(argvalues)
-        except TypeError:
-            raise InvalidParamsList(argvalues)
+    # transform argvalues to a list (it can be a generator)
+    try:
+        argvalues = list(argvalues)
+    except TypeError:
+        raise InvalidParamsList(argvalues)
 
-        # append **args
-        if len(kw_argnames) > 0:
-            argnames, argvalues = cart_product_pytest((argnames, kw_argnames),
-                                                      (argvalues, kw_argvalues))
+    # append **args
+    if len(kw_argnames) > 0:
+        argnames, argvalues = cart_product_pytest((argnames, kw_argnames),
+                                                  (argvalues, kw_argvalues))
 
     return argnames, argvalues
 

--- a/pytest_cases/tests/cases/doc/test_parametrize_alt.py
+++ b/pytest_cases/tests/cases/doc/test_parametrize_alt.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pytest_cases import parametrize_with_cases
+
+
+def case_sum_one_plus_two():
+    a = 1
+    b = 2
+    c = 3
+    return a, b, c
+
+
+@parametrize_with_cases(argnames=["a", "b", "c"], cases=".")
+def test_argnames_as_list(a, b, c):
+    assert a + b == c
+
+
+@parametrize_with_cases(argnames=("a", "b", "c"), cases=".")
+def test_argnames_as_tuple(a, b, c):
+    assert a + b == c
+
+
+def test_argnames_from_invalid_type():
+    with pytest.raises(
+            TypeError, match="^argnames should be a string, list or a tuple$"
+    ):
+        parametrize_with_cases(argnames=42, cases=".")(lambda _: None)
+
+
+def test_argnames_element_from_invalid_type():
+    with pytest.raises(
+            TypeError, match="^all argnames should be a strings$"
+    ):
+        parametrize_with_cases(argnames=["a", 2, "c"], cases=".")(lambda _: None)

--- a/pytest_cases/tests/cases/doc/test_parametrize_alt.py
+++ b/pytest_cases/tests/cases/doc/test_parametrize_alt.py
@@ -29,6 +29,6 @@ def test_argnames_from_invalid_type():
 
 def test_argnames_element_from_invalid_type():
     with pytest.raises(
-            TypeError, match="^all argnames should be a strings$"
+            TypeError, match="^all argnames should be strings$"
     ):
         parametrize_with_cases(argnames=["a", 2, "c"], cases=".")(lambda _: None)


### PR DESCRIPTION
Fix #133 

At the moment, the "argnames" parameter of `parametrize_with_cases` can only get strings as input, but it should except list of strings as well. 