### PR TITLE
Feature: parametrization with single case function from case class

### DIFF
--- a/pytest_cases/__init__.py
+++ b/pytest_cases/__init__.py
@@ -20,8 +20,19 @@ from .case_funcs_legacy import case_name, test_target, case_tags, cases_generato
 from .case_parametrizer_legacy import cases_data, CaseDataGetter, get_all_cases_legacy, \
     get_pytest_parametrize_args_legacy, cases_fixture
 
-from .case_funcs_new import case, copy_case_info, set_case_id, get_case_id, get_case_marks, \
-    get_case_tags, matches_tag_query, is_case_class, is_case_function
+from .case_funcs_new import (
+    case,
+    copy_case_info,
+    get_case_id,
+    set_case_id,
+    get_case_marks,
+    get_case_tags,
+    matches_tag_query,
+    is_case_class,
+    is_case_function,
+    is_case_class_unbound_method,
+    CaseGroupMeta,
+)
 from .case_parametrizer_new import parametrize_with_cases, THIS_MODULE, get_all_cases, get_parametrize_args
 
 try:
@@ -64,6 +75,7 @@ __all__ = [
     # case functions
     'case', 'copy_case_info', 'set_case_id', 'get_case_id', 'get_case_marks',
     'get_case_tags', 'matches_tag_query', 'is_case_class', 'is_case_function',
+    'is_case_class_unbound_method', 'CaseGroupMeta',
     # test functions
     'get_all_cases', 'parametrize_with_cases', 'THIS_MODULE', 'get_parametrize_args'
 ]

--- a/pytest_cases/case_funcs_new.py
+++ b/pytest_cases/case_funcs_new.py
@@ -73,7 +73,11 @@ class _CaseInfo(object):
                   case_func  # type: Callable
                   ):
         """attach this case_info to the given case function"""
-        setattr(case_func, CASE_FIELD, self)
+        if inspect.ismethod(case_func):
+            # we have a bound method; direct setattr will fail; attach to underlying function:
+            return self.attach_to(case_func.__func__)
+        else:
+            setattr(case_func, CASE_FIELD, self)
 
     def add_tags(self,
                  tags  # type: Union[Any, Union[List, Set, Tuple]]

--- a/pytest_cases/case_funcs_new.py
+++ b/pytest_cases/case_funcs_new.py
@@ -349,7 +349,11 @@ def is_case_class(cls,                                  # type: Any
     """
     return (
         isinstance(cls, CaseGroupMeta)
-        or safe_isclass(cls) and (not check_name or case_marker_in_name in cls.__name__)
+        or (
+            safe_isclass(cls)
+            and not issubclass(cls, type)  # exclude metaclasses
+            and (not check_name or case_marker_in_name in cls.__name__)
+        )
     )
 
 

--- a/pytest_cases/case_parametrizer_new.py
+++ b/pytest_cases/case_parametrizer_new.py
@@ -667,15 +667,16 @@ def _extract_cases_from_module_or_class(module=None,                      # type
             # Note: we used code.co_filename == module.__file__ in the past
             # but on some targets the file changes to a cached one so this does not work reliably,
             # see https://github.com/smarie/python-pytest-cases/issues/72
-            try:
-                return f.__module__ == module.__name__
-            except:  # noqa
-                return False
+            return getattr(f, "__module__", module.__name__) == module.__name__
     else:
         def _of_interest(x):  # noqa
             return True
 
     for m_name, m in getmembers(container, _of_interest):
+        # skip dunder names (e.g. __class__, __metaclass__, etc.) and "private" members:
+        if m_name.startswith("_"):
+            continue
+
         if is_case_class(m):
             co_firstlineno = get_code_first_line(m)
             cls_cases = extract_cases_from_class(m, case_fun_prefix=case_fun_prefix, _case_param_factory=_case_param_factory)

--- a/pytest_cases/tests/cases/issues/test_issue_159.py
+++ b/pytest_cases/tests/cases/issues/test_issue_159.py
@@ -1,0 +1,28 @@
+import six
+
+from pytest_cases import parametrize_with_cases, fixture
+from pytest_cases.case_funcs_new import CaseGroupMeta
+
+
+@fixture
+def compute_lazy_values():  # dummy fixture to ensure we don't get lazy values
+    pass
+
+
+@six.add_metaclass(CaseGroupMeta)
+class CaseGroup(object):
+    def case_first(self, compute_lazy_values):
+        return 1
+
+    def case_second(self, compute_lazy_values):
+        return 2
+
+
+@parametrize_with_cases("x", CaseGroup.case_first)
+def test_parametrize_with_single_case_method_unbound(x):
+    assert x == 1
+
+
+@parametrize_with_cases("x", CaseGroup().case_first)
+def test_parametrize_with_single_case_method_bound(x):
+    assert x == 1


### PR DESCRIPTION
Draft for #159. In Python 3 there's no reliable way to check whether a given function is an unbound method or just some free function defined outside a class. So I thought the best way to solve this is to explicitly add this information to test cases defined inside classes, in the form of a case class metaclass, `CaseGroupMeta`. This just adds an attribute to case functions defined inside the class that refers to the class they have been defined in.

This is not a breaking change in the sense that if people weren't using this feature, they won't need to set `CaseGroupMeta` as the metaclass of their case classes, but it might be a "breaking" change in the sense that probably users should be encouraged to use this metaclass in every case class from now on to ensure that they'll benefit from any fix/feature added to case classes in the future.

The tests weren't passing when I forked, so I'm not sure if I broke anything along the way :/ In any case the number of failing cases before and after was the same, so I guess no? I also added tests for this; both the `CaseGroup.case_func` version and the explicit `CaseGroup().case_func` (we don't want to penalize explicitness under any circumstance :) ).

What do you think?

Closes #159