### PR TITLE
fix: Wrap _getautousenames generator call in list()

### DIFF
--- a/pytest_cases/plugin.py
+++ b/pytest_cases/plugin.py
@@ -647,7 +647,7 @@ def create_super_closure(fm,
         print("Creating closure for %s:" % parentid)
 
     # -- auto-use fixtures
-    _init_fixnames = fm._getautousenames(parentid)  # noqa
+    _init_fixnames = list(fm._getautousenames(parentid))  # noqa
 
     def _merge(new_items, into_list):
         """ Appends items from `new_items` into `into_list`, only if they are not already there. """


### PR DESCRIPTION
Before pytest 6.2.0, `_getautousenames` returned a list. Now it returns a generator so it's necessary to explicitly collect it into a list. See #162 for more details.

Fixes #162