### PR TITLE
Fix #165: empty parameter set error

### DIFF
--- a/pytest_cases/common_pytest.py
+++ b/pytest_cases/common_pytest.py
@@ -4,6 +4,8 @@
 # License: 3-clause BSD, <https://github.com/smarie/python-pytest-cases/blob/master/LICENSE>
 from __future__ import division
 
+import sys
+
 from makefun import add_signature_parameters, wraps
 
 try:  # python 3.3+
@@ -537,8 +539,6 @@ def mini_idvalset(argnames, argvalues, idx):
 try:
     from _pytest.compat import getfuncargnames  # noqa
 except ImportError:
-    import sys
-
     def num_mock_patch_args(function):
         """ return number of arguments used up by mock arguments (if any) """
         patchings = getattr(function, "patchings", None)
@@ -588,7 +588,9 @@ class MiniFuncDef(object):
 class MiniMetafunc(Metafunc):
     # noinspection PyMissingConstructor
     def __init__(self, func):
-        self.config = None
+        from .plugin import PYTEST_CONFIG  # late import to ensure config has been loaded by now
+
+        self.config = PYTEST_CONFIG
         self.function = func
         self.definition = MiniFuncDef(func.__name__)
         self._calls = []

--- a/pytest_cases/plugin.py
+++ b/pytest_cases/plugin.py
@@ -1290,14 +1290,21 @@ def pytest_addoption(parser):
     )
 
 
+# will be loaded when the pytest_configure hook below is called
+PYTEST_CONFIG = None  # type: _pytest.config.Config
+
+
 # @hookspec(historic=True)
 def pytest_configure(config):
+    global PYTEST_CONFIG
     # validate the config
     allowed_values = ('normal', 'skip')
     reordering_choice = config.getoption(_OPTION_NAME)
     if reordering_choice not in allowed_values:
         raise ValueError("[pytest-cases] Wrong --%s option: %s. Allowed values: %s"
                          "" % (_OPTION_NAME, reordering_choice, allowed_values))
+    # store the received config object for future use; see #165 & #166
+    PYTEST_CONFIG = config
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/pytest_cases/tests/cases/issues/test_issue_165.py
+++ b/pytest_cases/tests/cases/issues/test_issue_165.py
@@ -1,0 +1,11 @@
+import pytest_cases
+
+
+@pytest_cases.parametrize(x=[])
+def case_empty(x):
+    return x  # pragma: no cover
+
+
+@pytest_cases.parametrize_with_cases("x", case_empty)
+def test_empty_parameter_set(x):
+    assert False  # pragma: no cover


### PR DESCRIPTION
The only public way to access the correct `config` object seems to be through the `pytestconfig` fixture, however I don't know how to get a hold of that outside a test function. So I used `get_config` from `_pytest.config`. No idea whether this is the correct approach but at least the test passes 😅 

-----------------

Update:

After taking a walk through pytest code with the company of a debugger, it seems *the* point at which the config object is constructed is here:

https://github.com/pytest-dev/pytest/blob/ad65e816e4612af4413711200f9e58d74e765a3a/src/_pytest/config/__init__.py#L143

Hence probably `_prepare_config` is the way to go? For now this PR adds a cached lazy `_get_config` static method to `MiniMetafunc` that calls `_prepare_config`. Ideally though it would be best to reuse the config object that pytest has already computed, but I have no idea how to get that from the `MiniMetafunc` code.

Fixes #165