### PR TITLE
Convert the result of _getautousenames to a list

### DIFF
--- a/pytest_cases/plugin.py
+++ b/pytest_cases/plugin.py
@@ -647,7 +647,7 @@ def create_super_closure(fm,
         print("Creating closure for %s:" % parentid)
 
     # -- auto-use fixtures
-    _init_fixnames = fm._getautousenames(parentid)  # noqa
+    _init_fixnames = list(fm._getautousenames(parentid))  # noqa
 
     def _merge(new_items, into_list):
         """ Appends items from `new_items` into `into_list`, only if they are not already there. """


### PR DESCRIPTION
This PR introduces a small fix for the latest version of pytest released 2 days ago.
As part of that release [in this pull request](https://github.com/pytest-dev/pytest/pull/7931), the return value of _getautousenames
was changed from a list to an iterator in order to fix a performance issue with autouse fixtures. 