### PR TITLE
Add parametrize random option

### DIFF
--- a/pytest_cases/__init__.py
+++ b/pytest_cases/__init__.py
@@ -10,7 +10,8 @@ AUTO2 = AUTO
 
 from .fixture_core1_unions import fixture_union, NOT_USED, unpack_fixture, ignore_unused
 from .fixture_core2 import pytest_fixture_plus, fixture_plus, param_fixtures, param_fixture
-from .fixture_parametrize_plus import pytest_parametrize_plus, parametrize_plus, fixture_ref
+from .fixture_parametrize_plus import pytest_parametrize_plus, parametrize_plus, \
+    parametrize_random, fixture_ref
 
 # additional symbols without the 'plus' suffix
 parametrize = parametrize_plus
@@ -50,7 +51,8 @@ __all__ = [
     # -- fixture core2
     'pytest_fixture_plus', 'fixture_plus', 'fixture', 'param_fixtures', 'param_fixture',
     # -- fixture parametrize plus
-    'pytest_parametrize_plus', 'parametrize_plus', 'parametrize', 'fixture_ref', 'lazy_value', 'is_lazy',
+    'pytest_parametrize_plus', 'parametrize_plus', 'parametrize', 'parametrize_random',
+    'fixture_ref', 'lazy_value', 'is_lazy',
 
     # V1 - DEPRECATED symbols
     # --cases_funcs

--- a/pytest_cases/fixture_parametrize_plus.py
+++ b/pytest_cases/fixture_parametrize_plus.py
@@ -2,6 +2,7 @@
 #          + All contributors to <https://github.com/smarie/python-pytest-cases>
 #
 # License: 3-clause BSD, <https://github.com/smarie/python-pytest-cases/blob/master/LICENSE>
+import random
 from collections import Iterable
 from inspect import isgeneratorfunction
 from warnings import warn
@@ -680,6 +681,43 @@ def parametrize_plus(argnames=None,       # type: str
         return _apply_parametrize_plus
     else:
         return _decorate
+
+
+def parametrize_random(argnames=None,
+                       argvalues=None,
+                       indirect=False,      # type: bool
+                       ids=None,            # type: Union[Callable, Iterable[str]]
+                       idstyle=None,        # type: Optional[Union[str, Callable]]
+                       idgen=_IDGEN,        # type: Union[str, Callable]
+                       auto_refs=True,      # type: bool
+                       scope=None,          # type: str
+                       hook=None,           # type: Callable[[Callable], Callable]
+                       debug=False,         # type: bool
+                       size=1,              # type: int
+                       **args):
+    """
+
+    :return: a tuple (decorator, needs_inject) where needs_inject is True if decorator has signature (f, host)
+        and False if decorator has signature (f)
+    """
+    argnames, argvalues = _get_argnames_argvalues(argnames, argvalues, **args)
+    if size < 1 or size > len(argvalues):
+        raise ValueError(
+            "Size should be between 1 and {}. Got {}".format(len(argvalues), size)
+        )
+    argvalues = random.sample(argvalues, size)
+    return parametrize_plus(
+        argnames=argnames,
+        argvalues=argvalues,
+        indirect=indirect,
+        ids=ids,
+        idstyle=idstyle,
+        idgen=idgen,
+        auto_refs=auto_refs,
+        scope=scope,
+        hook=hook,
+        debug=debug,
+    )
 
 
 class InvalidIdTemplateException(Exception):

--- a/pytest_cases/tests/pytest_extension/parametrize_plus/test_parametrize_random.py
+++ b/pytest_cases/tests/pytest_extension/parametrize_plus/test_parametrize_random.py
@@ -1,0 +1,6 @@
+from pytest_cases import parametrize_random
+
+
+@parametrize_random(value=list(range(8)), size=3)
+def test_parametrize_random(value):
+    print(value)


### PR DESCRIPTION
Added the ability to run a parametrize test with a subset of the given values.

**Why do we need it?**
Sometimes you want to check that a method/class/etc. work as expected, but the specific values are not important. One might select randomly a valid/invalid value in that case and run the test with that value.

Now you can do this exact thing with `parametrize_random`. Just use the `argnames` and `argvalues` parameters as you do for the "regular" parameterized test, but choose how many samples of those arguments to take using the `size` argument.