### PR TITLE
Move _CaseInfo to its own module

### DIFF
--- a/pytest_cases/case_funcs_new.py
+++ b/pytest_cases/case_funcs_new.py
@@ -4,7 +4,7 @@
 # License: 3-clause BSD, <https://github.com/smarie/python-pytest-cases/blob/master/LICENSE>
 from decopatch import function_decorator, DECORATED
 
-from .case_info import _CaseInfo, _tags_match_query
+from .case_info import CaseInfo, _tags_match_query
 
 try:  # python 3.5+
     from typing import Type, Callable, Union, Optional, Any, Tuple, Dict, Iterable, List, Set
@@ -32,14 +32,14 @@ def copy_case_info(from_fun,  # type: Callable
                    to_fun     # type: Callable
                    ):
     """Copy all information from case function `from_fun` to `to_fun`."""
-    _CaseInfo.copy_info(from_fun, to_fun)
+    CaseInfo.copy_info(from_fun, to_fun)
 
 
 def set_case_id(id,        # type: str
                 case_func  # type: Callable
                 ):
     """Set an explicit id on case function `case_func`."""
-    ci = _CaseInfo.get_from(case_func, create_if_missing=True)
+    ci = CaseInfo.get_from(case_func, create_if_missing=True)
     ci.id = id
 
 
@@ -57,7 +57,7 @@ def get_case_id(case_func,                              # type: Callable
         case id.
     :return:
     """
-    _ci = _CaseInfo.get_from(case_func)
+    _ci = CaseInfo.get_from(case_func)
     _id = _ci.id if _ci is not None else None
 
     if _id is None:
@@ -95,7 +95,7 @@ def get_case_marks(case_func,                         # type: Callable
         returned. Otherwise (default) the marks are returned as is.
     :return:
     """
-    _ci = _CaseInfo.get_from(case_func)
+    _ci = CaseInfo.get_from(case_func)
     if _ci is None:
         _ci_marks = None
     else:
@@ -119,7 +119,7 @@ def get_case_marks(case_func,                         # type: Callable
 def get_case_tags(case_func  # type: Callable
                   ):
     """Return the tags on this case function or an empty tuple"""
-    ci = _CaseInfo.get_from(case_func)
+    ci = CaseInfo.get_from(case_func)
     return ci.tags if ci is not None else ()
 
 
@@ -198,7 +198,7 @@ def case(id=None,             # type: str  # noqa
     :return:
     """
     marks = markdecorators_as_tuple(marks)
-    case_info = _CaseInfo(id, marks, tags)
+    case_info = CaseInfo(id, marks, tags)
     case_info.attach_to(case_func)
     return case_func
 

--- a/pytest_cases/case_funcs_new.py
+++ b/pytest_cases/case_funcs_new.py
@@ -2,16 +2,15 @@
 #          + All contributors to <https://github.com/smarie/python-pytest-cases>
 #
 # License: 3-clause BSD, <https://github.com/smarie/python-pytest-cases/blob/master/LICENSE>
-from copy import copy
-
 from decopatch import function_decorator, DECORATED
+
+from .case_info import _CaseInfo, _tags_match_query
 
 try:  # python 3.5+
     from typing import Type, Callable, Union, Optional, Any, Tuple, Dict, Iterable, List, Set
 except ImportError:
     pass
 
-from .common_mini_six import string_types
 from .common_pytest import safe_isclass
 from .common_pytest_marks import get_pytest_marks_on_function, markdecorators_as_tuple, markdecorators_to_markinfos
 
@@ -19,84 +18,6 @@ try:
     from _pytest.mark.structures import MarkDecorator, Mark
 except ImportError:
     pass
-
-CASE_FIELD = '_pytestcase'
-
-
-class _CaseInfo(object):
-    """
-    Contains all information available about a case.
-    It is attached to a case function as an attribute
-    """
-    __slots__ = ('id', 'marks', 'tags')
-
-    def __init__(self,
-                 id=None,   # type: str
-                 marks=(),  # type: Tuple[MarkDecorator, ...]
-                 tags=()    # type: Tuple[Any]
-                 ):
-        self.id = id
-        self.marks = marks
-        self.tags = ()
-        self.add_tags(tags)
-
-    def __repr__(self):
-        return "_CaseInfo(id=%r,marks=%r,tags=%r)" % (self.id, self.marks, self.tags)
-
-    @classmethod
-    def get_from(cls,
-                 case_func,               # type: Callable
-                 create_if_missing=False  # type: bool
-                 ):
-        """ Return the _CaseInfo associated with case_fun or None
-
-        :param case_func:
-        :param create_if_missing: if no case information is present on the function, by default None is returned. If
-            this flag is set to True, a new _CaseInfo will be created and attached on the function, and returned.
-        """
-        ci = getattr(case_func, CASE_FIELD, None)
-        if ci is None and create_if_missing:
-            ci = cls()
-            ci.attach_to(case_func)
-        return ci
-
-    def attach_to(self,
-                  case_func  # type: Callable
-                  ):
-        """attach this case_info to the given case function"""
-        setattr(case_func, CASE_FIELD, self)
-
-    def add_tags(self,
-                 tags  # type: Union[Any, Union[List, Set, Tuple]]
-                 ):
-        """add the given tag or tags"""
-        if tags:
-            if isinstance(tags, string_types) or not isinstance(tags, (set, list, tuple)):
-                # a single tag, create a tuple around it
-                tags = (tags,)
-
-            self.tags += tuple(tags)
-
-    def matches_tag_query(self,
-                          has_tag=None,  # type: Union[str, Iterable[str]]
-                          ):
-        """
-        Returns True if the case function with this case_info is selected by the query
-
-        :param has_tag:
-        :return:
-        """
-        return _tags_match_query(self.tags, has_tag)
-
-    @classmethod
-    def copy_info(cls,
-                  from_case_func,
-                  to_case_func):
-        case_info = cls.get_from(from_case_func)
-        if case_info is not None:
-            # there is something to copy: do it
-            cp = copy(case_info)
-            cp.attach_to(to_case_func)
 
 
 # ------------------ API --------------
@@ -250,21 +171,6 @@ def matches_tag_query(case_fun,      # type: Callable
                 selected = False
 
     return selected
-
-
-def _tags_match_query(tags,    # type: Iterable[str]
-                      has_tag  # type: Optional[Union[str, Iterable[str]]]
-                      ):
-    """Internal routine to determine is all tags in `has_tag` are persent in `tags`
-    Note that `has_tag` can be a single tag, or none
-    """
-    if has_tag is None:
-        return True
-
-    if not isinstance(has_tag, (tuple, list, set)):
-        has_tag = (has_tag,)
-
-    return all(t in tags for t in has_tag)
 
 
 @function_decorator

--- a/pytest_cases/case_info.py
+++ b/pytest_cases/case_info.py
@@ -10,7 +10,7 @@ from .common_mini_six import string_types
 CASE_FIELD = '_pytestcase'
 
 
-class _CaseInfo(object):
+class CaseInfo(object):
     """
     Contains all information available about a case.
     It is attached to a case function as an attribute

--- a/pytest_cases/case_info.py
+++ b/pytest_cases/case_info.py
@@ -1,0 +1,101 @@
+from copy import copy
+
+try:  # python 3.5+
+    from typing import Type, Callable, Union, Optional, Any, Tuple, Dict, Iterable, List, Set
+except ImportError:
+    pass
+from .common_mini_six import string_types
+
+
+CASE_FIELD = '_pytestcase'
+
+
+class _CaseInfo(object):
+    """
+    Contains all information available about a case.
+    It is attached to a case function as an attribute
+    """
+    __slots__ = ('id', 'marks', 'tags')
+
+    def __init__(self,
+                 id=None,   # type: str
+                 marks=(),  # type: Tuple[MarkDecorator, ...]
+                 tags=()    # type: Tuple[Any]
+                 ):
+        self.id = id
+        self.marks = marks
+        self.tags = ()
+        self.add_tags(tags)
+
+    def __repr__(self):
+        return "_CaseInfo(id=%r,marks=%r,tags=%r)" % (self.id, self.marks, self.tags)
+
+    @classmethod
+    def get_from(cls,
+                 case_func,               # type: Callable
+                 create_if_missing=False  # type: bool
+                 ):
+        """ Return the _CaseInfo associated with case_fun or None
+
+        :param case_func:
+        :param create_if_missing: if no case information is present on the function, by default None is returned. If
+            this flag is set to True, a new _CaseInfo will be created and attached on the function, and returned.
+        """
+        ci = getattr(case_func, CASE_FIELD, None)
+        if ci is None and create_if_missing:
+            ci = cls()
+            ci.attach_to(case_func)
+        return ci
+
+    def attach_to(self,
+                  case_func  # type: Callable
+                  ):
+        """attach this case_info to the given case function"""
+        setattr(case_func, CASE_FIELD, self)
+
+    def add_tags(self,
+                 tags  # type: Union[Any, Union[List, Set, Tuple]]
+                 ):
+        """add the given tag or tags"""
+        if tags:
+            if isinstance(tags, string_types) or not isinstance(tags, (set, list, tuple)):
+                # a single tag, create a tuple around it
+                tags = (tags,)
+
+            self.tags += tuple(tags)
+
+    def matches_tag_query(self,
+                          has_tag=None,  # type: Union[str, Iterable[str]]
+                          ):
+        """
+        Returns True if the case function with this case_info is selected by the query
+
+        :param has_tag:
+        :return:
+        """
+        return _tags_match_query(self.tags, has_tag)
+
+    @classmethod
+    def copy_info(cls,
+                  from_case_func,
+                  to_case_func):
+        case_info = cls.get_from(from_case_func)
+        if case_info is not None:
+            # there is something to copy: do it
+            cp = copy(case_info)
+            cp.attach_to(to_case_func)
+
+
+def _tags_match_query(tags,    # type: Iterable[str]
+                      has_tag  # type: Optional[Union[str, Iterable[str]]]
+                      ):
+    """Internal routine to determine is all tags in `has_tag` are persent in `tags`
+    Note that `has_tag` can be a single tag, or none
+    """
+    if has_tag is None:
+        return True
+
+    if not isinstance(has_tag, (tuple, list, set)):
+        has_tag = (has_tag,)
+
+    return all(t in tags for t in has_tag)


### PR DESCRIPTION
Moved the `_CaseInfo` class to *case_info.py*

Initially was implemented in #184.

**Why is it good for us?**
`_CaseInfo` is a basic class with no dependencies in this package.
Therefore, it should exist on its own module, letting multiple modules import it.
In that way, we can avoid future cyclic imports.

**Further Suggestion**
I think `_CaseInfo` is not necessarily a private class. I see no reason why not to rename it to `CaseInfo` without the underscore prefix.
If you also think so, let me know and I'll add this change to this PR.
