### PR TITLE
Fix for #234

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,12 @@
 # Changelog
 
+### 3.6.5 - Bugfix
+
+ - Fixed an issue where using keyword `argnames` in `@pytest.mark.parametrize` would cause `IndexError: tuple index out of range` in the tests collection phase. Fixed [#234](https://github.com/smarie/python-pytest-cases/issues/234).
+
 ### 3.6.4 - Bugfix
 
-- A case id can now be a reserved keyword without triggering any `SyntaxError`, even if the case is transformed into a fixture. Fixes [#230](https://github.com/smarie/python-pytest-cases/issues/230)
+ - A case id can now be a reserved keyword without triggering any `SyntaxError`, even if the case is transformed into a fixture. Fixes [#230](https://github.com/smarie/python-pytest-cases/issues/230)
 
 ### 3.6.3 - Bugfix
 

--- a/pytest_cases/common_pytest.py
+++ b/pytest_cases/common_pytest.py
@@ -241,7 +241,8 @@ def get_param_names(fnode):
     p_markers = get_parametrization_markers(fnode)
     param_names = []
     for paramz_mark in p_markers:
-        param_names += get_param_argnames_as_list(paramz_mark.args[0])
+        argnames = paramz_mark.args[0] if len(paramz_mark.args) > 0 else paramz_mark.kwargs['argnames']
+        param_names += get_param_argnames_as_list(argnames)
     return param_names
 
 

--- a/pytest_cases/tests/pytest_extension/issues/test_issue_234.py
+++ b/pytest_cases/tests/pytest_extension/issues/test_issue_234.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    argnames="test_arg",
+    argvalues=[1, 2, 3]
+)
+def test_keyword_paramz(test_arg):
+    assert True


### PR DESCRIPTION
Fixed an issue where using keyword `argnames` in `@pytest.mark.parametrize` would cause `IndexError: tuple index out of range` in the tests collection phase. 

Fixed #234
