### PR TITLE
Fix parametrize argnames typing

### DIFF
--- a/src/pytest_cases/fixture_parametrize_plus.py
+++ b/src/pytest_cases/fixture_parametrize_plus.py
@@ -613,7 +613,7 @@ class ParamIdMakers(UnionIdMakers):
 _IDGEN = object()
 
 
-def parametrize(argnames=None,   # type: str
+def parametrize(argnames=None,   # type: Union[str, List[str]]
                 argvalues=None,  # type: Iterable[Any]
                 indirect=False,  # type: bool
                 ids=None,        # type: Union[Callable, Iterable[str]]


### PR DESCRIPTION
When using the fixture `parametrize`, one can use the parameter `argnames` as a string separated with commas or a list of strings.

However, the type hint used is only `str`, which causes **mypy** to fail on my code, even though I use the  fixture correctly.

Fixed that by changing the type of the paramter.