### PR TITLE
workaround for CallSpec2 attributes being frozen

### DIFF
--- a/src/pytest_cases/fixture_parametrize_plus.py
+++ b/src/pytest_cases/fixture_parametrize_plus.py
@@ -550,14 +550,20 @@ class ProductParamAlternative(SingleParamAlternative):
 EMPTY_ID = "<pytest_cases_empty_id>"
 
 
+def _replace_list_contents(the_list, new_contents):
+    """Replaces the contents of a list"""
+    the_list.clear()
+    the_list.extend(new_contents)
+
+
 if has_pytest_param:
     def remove_empty_ids(callspec):
         # used by plugin.py to remove the EMPTY_ID from the callspecs
-        callspec._idlist = [c for c in callspec._idlist if not c.startswith(EMPTY_ID)]
+        _replace_list_contents(callspec._idlist, [c for c in callspec._idlist if not c.startswith(EMPTY_ID)])
 else:
     def remove_empty_ids(callspec):
         # used by plugin.py to remove the EMPTY_ID from the callspecs
-        callspec._idlist = [c for c in callspec._idlist if not c.endswith(EMPTY_ID)]
+        _replace_list_contents(callspec._idlist, [c for c in callspec._idlist if not c.endswith(EMPTY_ID)])
 
 
 # elif PYTEST421_OR_GREATER:


### PR DESCRIPTION
Fixes #251

In pytest 7, CallSpec2 was [refactored](https://github.com/pytest-dev/pytest/commit/570b1facb7845cb493fe73a94ac47c9704f609f5) and it made attributes read-only causing the issue from #251. 

before this change, running pytest on the example from #251:
```text
plugins: cases-3.6.8
collected 0 items / 1 error

=================================================================== ERRORS ===================================================================
__________________________________________________ ERROR collecting tests/issue_221_test.py __________________________________________________
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\pluggy\_hooks.py:265: in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\pluggy\_manager.py:80: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\_pytest\python.py:257: in pytest_pycollect_makeitem
    res = list(collector._genfunctions(name, obj))
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\_pytest\python.py:487: in _genfunctions
    fixtures.add_funcarg_pseudo_fixture_def(self, metafunc, fm)
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\_pytest\fixtures.py:164: in add_funcarg_pseudo_fixture_def
    if not metafunc._calls[0].funcargs:
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\pytest_cases\plugin.py:931: in __getitem__
    return self.calls_list[item]
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\pytest_cases\plugin.py:942: in calls_list
    self.create_call_list_from_pending_parametrizations()
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\pytest_cases\plugin.py:994: in create_call_list_from_pending_parametrizations
    remove_empty_ids(callspec)
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\pytest_cases\fixture_parametrize_plus.py:560: in remove_empty_ids
    callspec._idlist = [c for c in callspec._idlist if not c.startswith(EMPTY_ID)]
..\.virtualenvs\pytest-cases-test-aSbyvtak\lib\site-packages\attr\_make.py:642: in _frozen_setattrs
    raise FrozenInstanceError()
E   attr.exceptions.FrozenInstanceError
========================================================== short test summary info ===========================================================
ERROR tests/issue_221_test.py - attr.exceptions.FrozenInstanceError
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================== 1 error in 0.52s ==============================================================
```

With this change:

```text
plugins: cases-3.6.8
collected 2 items

tests\issue_221_test.py ..                                                                                                              [100%]

============================================================= 2 passed in 0.05s ==============================================================
```