### PR TITLE
Add: `get_all_cases` extended to support filtering and use other modules as `parametrization_target`

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -347,7 +347,7 @@ Collect all cases as used with [`@parametrize_with_cases`](#parametrize_with_cas
 
 This can be used to lists all desired cases for a given `parametrization_target` (a test function or a fixture) which may be convenient for debugging purposes.
 
- - If `cases` is `AUTO`, `"."` or contains a string module reference, `parametrization_target` must be provided.
+ - If `cases` is `AUTO` or contains a string module reference, `parametrization_target` must be provided.
 
 ```python
 # Without a parametrization target

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -280,7 +280,7 @@ Note that `@parametrize_with_cases` collection and parameter creation steps are 
 
 ```python
 # Collect all cases
-cases_funs = get_all_cases(f, cases=cases, prefix=prefix, 
+cases_funs = get_all_cases(f, cases=cases, prefix=prefix,
                            glob=glob, has_tag=has_tag, filter=filter)
 
 # Transform the various functions found
@@ -335,7 +335,7 @@ Note that you can get the same contents directly by using the [`current_cases`](
 ### `get_all_cases`
 
 ```python
-def get_all_cases(parametrization_target: Callable,
+def get_all_cases(parametrization_target: Callable = None,
                   cases: Union[Callable, Type, ModuleRef] = None,
                   prefix: str = 'case_',
                   glob: str = None,
@@ -343,8 +343,19 @@ def get_all_cases(parametrization_target: Callable,
                   filter: Callable[[Callable], bool] = None
                   ) -> List[Callable]:
 ```
+Collect all cases as used with [`@parametrize_with_cases`](#parametrize_with_cases). See [`@parametrize_with_cases`](#parametrize_with_cases) for details on the parameters.
 
-Lists all desired cases for a given `parametrization_target` (a test function or a fixture). This function may be convenient for debugging purposes. See [`@parametrize_with_cases`](#parametrize_with_cases) for details on the parameters.
+This can be used to lists all desired cases for a given `parametrization_target` (a test function or a fixture) which may be convenient for debugging purposes.
+
+ - If `cases` is `AUTO`, `"."` or contains a string module reference, `parametrization_target` must be provided.
+
+```python
+# Without a parametrization target
+cases = get_all_cases(cases=[case_1, case_2, case_3], has_tag=["banana"])
+
+# With a parametrization target
+cases = get_all_cases(f, cases=".", has_tag=["banana"])
+```
 
 
 ### `get_parametrize_args`

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -47,7 +47,7 @@ def case_hi():
  - `id`: the custom pytest id that should be used when this case is active. Replaces the deprecated `@case_name` decorator from v1. If no id is provided, the id is generated from case functions by removing their prefix, see [`@parametrize_with_cases(prefix='case_')`](#parametrize_with_cases).
 
  - `tags`: custom tags to be used for filtering in [`@parametrize_with_cases(has_tags)`](#parametrize_with_cases). Replaces the deprecated `@case_tags` and `@target` decorators.
- 
+
  - `marks`: optional pytest marks to add on the case. Note that decorating the function directly with the mark also works, and if marks are provided in both places they are merged.
 
 
@@ -343,19 +343,24 @@ def get_all_cases(parametrization_target: Callable = None,
                   filter: Callable[[Callable], bool] = None
                   ) -> List[Callable]:
 ```
-Collect all cases as used with [`@parametrize_with_cases`](#parametrize_with_cases). See [`@parametrize_with_cases`](#parametrize_with_cases) for details on the parameters.
-
+Collect all cases as used with [`@parametrize_with_cases`](#parametrize_with_cases). See [`@parametrize_with_cases`](#parametrize_with_cases) for more details on the parameters.
 This can be used to lists all desired cases for a given `parametrization_target` (a test function or a fixture) which may be convenient for debugging purposes.
 
- - If `cases` is `AUTO` or contains a string module reference, `parametrization_target` must be provided.
-
 ```python
-# Without a parametrization target
-cases = get_all_cases(cases=[case_1, case_2, case_3], has_tag=["banana"])
+# Get the cases for f that are defined in the current file
+cases = get_all_cases(f, cases=".")
 
-# With a parametrization target
-cases = get_all_cases(f, cases=".", has_tag=["banana"])
+# Get the cases from cases_xyz.py or test_xyz_cases.py
+import test.test_xyz
+xyz_cases = get_all_cases(test.test_xyz)
+
+# Can be used to filter explict cases, in which case no parametrization_target is needed
+filtered_cases = get_all_cases(cases=[case_1, case_2, case_3], has_tag=["banana"])
 ```
+
+ - If using a `cases` argument that requires module information, such as `"."` `AUTO` or a relative module like `".xyz"`, the value of `parametrization_target` will be used to to determine the context.
+ If `None` or simply left empty, it will use the module from which `get_all_cases` was called.
+ You can pass an explicit module object or a function, in which case the module in which it's defined will be used.
 
 
 ### `get_parametrize_args`

--- a/src/pytest_cases/case_parametrizer_new.py
+++ b/src/pytest_cases/case_parametrizer_new.py
@@ -205,7 +205,7 @@ def create_glob_name_filter(glob_str  # type: str
     return _glob_name_filter
 
 
-def get_all_cases(parametrization_target=None,  # type: Optional[Callable]
+def get_all_cases(parametrization_target=None,  # type: Callable
                   cases=None,                   # type: Union[Callable, Type, ModuleRef]
                   prefix=CASE_PREFIX_FUN,       # type: str
                   glob=None,                    # type: str
@@ -266,14 +266,9 @@ def get_all_cases(parametrization_target=None,  # type: Optional[Callable]
 
         filters += (filter,)
 
-    # Validate that we have a parametrization target
+    # Validate that we have a parametrization target if required for retrieving cases
     if parametrize_with_cases is None:
-        if any(
-            c is AUTO
-            or c is THIS_MODULE
-            or (isinstance(c, str) and c.beginswith("."))
-            for c in cases
-        ):
+        if any(c is AUTO or c is THIS_MODULE or isinstance(c, str) for c in cases):
             raise ValueError(
                 "Cases beginning with '.' or using AUTO require a parametrization target,"
                 " please use `get_all_cases(target_func, cases=...)`"
@@ -301,7 +296,6 @@ def get_all_cases(parametrization_target=None,  # type: Optional[Callable]
             else:
                 raise ValueError("Unsupported case function: %r" % c)
         else:
-
             # module
             if c is AUTO:
                 # First try `test_<name>_cases.py` Then `case_<name>.py`

--- a/src/pytest_cases/case_parametrizer_new.py
+++ b/src/pytest_cases/case_parametrizer_new.py
@@ -37,7 +37,7 @@ from .case_funcs import matches_tag_query, is_case_function, is_case_class, CASE
 
 from .fixture_core1_unions import USED, NOT_USED
 from .fixture_core2 import CombinedFixtureParamValue, fixture
-from .fixture__creation import check_name_available, CHANGE
+from .fixture__creation import check_name_available, get_caller_module, CHANGE
 from .fixture_parametrize_plus import fixture_ref, _parametrize_plus, FixtureParamAlternative, ParamAlternative, \
     SingleParamAlternative, MultiParamAlternative, FixtureRefItem
 
@@ -266,18 +266,13 @@ def get_all_cases(parametrization_target=None,  # type: Callable
 
         filters += (filter,)
 
-    # Validate that we have a parametrization target if required for retrieving cases
-    if parametrization_target is None:
-        if any(c is AUTO or c is THIS_MODULE or isinstance(c, str) for c in cases):
-            raise ValueError(
-                "Cases beginning with '.' or using AUTO require a parametrization target,"
-                " please use `get_all_cases(target_func, cases=...)`"
-            )
-
     # parent package
-    if parametrization_target is not None:
+    if parametrization_target is None:
         caller_module_name = getattr(parametrization_target, '__module__', None)
-        parent_pkg_name = '.'.join(caller_module_name.split('.')[:-1]) if caller_module_name is not None else None
+    else:
+        caller_module_name = get_caller_module()
+
+    parent_pkg_name = '.'.join(caller_module_name.split('.')[:-1]) if caller_module_name is not None else None
 
     # start collecting all cases
     cases_funs = []

--- a/src/pytest_cases/case_parametrizer_new.py
+++ b/src/pytest_cases/case_parametrizer_new.py
@@ -217,8 +217,8 @@ def get_all_cases(parametrization_target=None,  # type: Callable
     Lists all desired cases for a given `parametrization_target` (a test function or a fixture). This function may be
     convenient for debugging purposes. See `@parametrize_with_cases` for details on the parameters.
 
-    :param parametrization_target: a test function to get the module reference from. Required for cases that
-        rely on module reference.
+    :param parametrization_target: either an explicit module object or a function or None. If it's a function, it will
+        use the module it is defined in. If None is given, it will just get the module it was called from.
     :param cases: a case function, a class containing cases, a module or a module name string (relative module
         names accepted). Or a list of such items. You may use `THIS_MODULE` or `'.'` to include current module.
         `AUTO` (default) means that the module named `test_<name>_cases.py` will be loaded, where `test_<name>.py` is
@@ -268,9 +268,14 @@ def get_all_cases(parametrization_target=None,  # type: Callable
 
     # parent package
     if parametrization_target is None:
+        parametrization_target = get_caller_module()
+
+    if ismodule(parametrization_target):
+        caller_module_name = parametrization_target.__name__
+    elif callable(parametrization_target):
         caller_module_name = getattr(parametrization_target, '__module__', None)
     else:
-        caller_module_name = get_caller_module()
+        raise ValueError("Can't handle parametrization_target=%s" % parametrization_target)
 
     parent_pkg_name = '.'.join(caller_module_name.split('.')[:-1]) if caller_module_name is not None else None
 
@@ -298,6 +303,7 @@ def get_all_cases(parametrization_target=None,  # type: Callable
 
             elif c is THIS_MODULE or c == '.':
                 c = caller_module_name
+
             new_cases = extract_cases_from_module(c, package_name=parent_pkg_name, case_fun_prefix=prefix)
             cases_funs += new_cases
 
@@ -640,31 +646,41 @@ def _get_fixture_cases(module_or_class  # type: Union[ModuleType, Type]
     return cache, imported_fixtures_list
 
 
-def import_default_cases_module(f):
+def import_default_cases_module(context):
     """
-    Implements the `module=AUTO` behaviour of `@parameterize_cases`: based on the decorated test function `f`,
-    it finds its containing module name "test_<module>.py" and then tries to import the python module
-    "test_<module>_cases.py".
+    Implements the `module=AUTO` behaviour of `@parameterize_cases`: based on the context
+    passed in. This can either a <module> object or a decorated test function in which
+    case it finds its containing module name "test_<module>.py" and then tries to import
+    the python module "test_<module>_cases.py".
 
-    If the module is not found it looks for the alternate file `cases_<module>.py`.
+    If "test_<module>_cases.py" module is not found it looks for the alternate
+    file `cases_<module>.py`.
 
-    :param f: the decorated test function
+    :param f: the decorated test function or a module
     :return:
     """
+    if ismodule(context):
+        module_name = context.__name__
+    elif hasattr(context, "__module__"):
+        module_name = context.__module__
+    else:
+        raise ValueError("Can't get module from context %s" % context)
+
     # First try `test_<name>_cases.py`
-    cases_module_name1 = "%s_cases" % f.__module__
+    cases_module_name1 = "%s_cases" % module_name
+
     try:
         cases_module = import_module(cases_module_name1)
     except ModuleNotFoundError:
         # Then try `case_<name>.py`
-        parts = f.__module__.split('.')
+        parts = module_name.split('.')
         assert parts[-1][0:5] == 'test_'
         cases_module_name2 = "%s.cases_%s" % ('.'.join(parts[:-1]), parts[-1][5:])
         try:
             cases_module = import_module(cases_module_name2)
         except ModuleNotFoundError:
             # Nothing worked
-            raise ValueError("Error importing test cases module to parametrize function %r: unable to import AUTO "
+            raise ValueError("Error importing test cases module to parametrize %r: unable to import AUTO "
                              "cases module %r nor %r. Maybe you wish to import cases from somewhere else ? In that case"
                              "please specify `cases=...`."
                              % (f, cases_module_name1, cases_module_name2))

--- a/src/pytest_cases/case_parametrizer_new.py
+++ b/src/pytest_cases/case_parametrizer_new.py
@@ -267,7 +267,7 @@ def get_all_cases(parametrization_target=None,  # type: Callable
         filters += (filter,)
 
     # Validate that we have a parametrization target if required for retrieving cases
-    if parametrize_with_cases is None:
+    if parametrization_target is None:
         if any(c is AUTO or c is THIS_MODULE or isinstance(c, str) for c in cases):
             raise ValueError(
                 "Cases beginning with '.' or using AUTO require a parametrization target,"

--- a/tests/cases/issues/issue_258/cases.py
+++ b/tests/cases/issues/issue_258/cases.py
@@ -1,0 +1,10 @@
+from pytest_cases import case
+
+@case
+def case_1():
+    return "hello world"
+
+
+@case
+def case_2():
+    return "hello mars"

--- a/tests/cases/issues/issue_258/cases.py
+++ b/tests/cases/issues/issue_258/cases.py
@@ -1,10 +1,12 @@
+# Imported explicitly or with ".cases"
 from pytest_cases import case
+
 
 @case
 def case_1():
-    return "hello world"
+    return "hello ."
 
 
 @case
 def case_2():
-    return "hello mars"
+    return "hi ."

--- a/tests/cases/issues/issue_258/cases_issue_258.py
+++ b/tests/cases/issues/issue_258/cases_issue_258.py
@@ -1,0 +1,11 @@
+from pytest_cases import case
+
+
+@case
+def case_1():
+    return "hello world"
+
+
+@case
+def case_2():
+    return "hello mars"

--- a/tests/cases/issues/issue_258/cases_other.py
+++ b/tests/cases/issues/issue_258/cases_other.py
@@ -1,0 +1,13 @@
+# Used by passing the corresponding module `test_other` to `get_all_cases`
+# `get_all_cases(test_other)`
+from pytest_cases import case
+
+
+@case
+def case_1():
+    return "hello cases_other"
+
+
+@case
+def case_2():
+    return "hi cases_other"

--- a/tests/cases/issues/issue_258/test_issue_258.py
+++ b/tests/cases/issues/issue_258/test_issue_258.py
@@ -1,11 +1,10 @@
-#  Authors: Eddie Bergmane <eddiebergmanehs@gmail.com>
-#            + All contributors to <https://github.com/smarie/python-pyfields>
-#
-#  License: 3-clause BSD, <https://github.com/smarie/python-pyfields/blob/master/LICENSE>
-#
-#  Issue: https://github.com/smarie/python-pytest-cases/issues/258
-from pytest_cases import get_all_cases, case, parametrize_with_cases
+from pytest_cases import get_all_cases, case, parametrize_with_cases, parametrize
+import pytest
+from pytest_cases.case_parametrizer_new import AUTO
 
+
+# Test behaviour without a string module ref
+############################################
 
 @case(tags=["a", "banana"])
 def case_1():
@@ -60,3 +59,21 @@ def test_get_cases_without_parametrization_target():
     assert len(list(a_cases)) == 2
     assert len(list(b_cases)) == 2
     assert len(list(banana_cases)) == 2
+
+
+@parametrize("ref", ['.'])
+def test_get_all_cases_raises_with_module_case(ref):
+    with pytest.raises(ValueError, match="Cases beginning with"):
+        get_all_cases(cases=ref)
+
+
+# Test behaviour with string module ref
+#######################################
+def test_relative_import_cases_is_none_empty():
+    relative_import_cases = get_all_cases(cases=".cases")
+    assert len(relative_import_cases) == 2
+
+
+def test_auto_import_cases_is_non_empty():
+    auto_import_cases = get_all_cases(cases=AUTO)
+    assert len(auto_import_cases) == 2

--- a/tests/cases/issues/issue_258/test_other.py
+++ b/tests/cases/issues/issue_258/test_other.py
@@ -1,12 +1,11 @@
-# Import with AUTO
 from pytest_cases import case
 
 
 @case
 def case_1():
-    return "hello AUTO"
+    return "hello test_other"
 
 
 @case
 def case_2():
-    return "hi AUTO"
+    return "hi test_other"

--- a/tests/cases/issues/test_issue_258.py
+++ b/tests/cases/issues/test_issue_258.py
@@ -1,0 +1,62 @@
+#  Authors: Eddie Bergmane <eddiebergmanehs@gmail.com>
+#            + All contributors to <https://github.com/smarie/python-pyfields>
+#
+#  License: 3-clause BSD, <https://github.com/smarie/python-pyfields/blob/master/LICENSE>
+#
+#  Issue: https://github.com/smarie/python-pytest-cases/issues/258
+from pytest_cases import get_all_cases, case, parametrize_with_cases
+
+
+@case(tags=["a", "banana"])
+def case_1():
+    return "a_banana"
+
+
+@case(tags=["a"])
+def case_2():
+    return "a"
+
+
+@case(tags=["b", "banana"])
+def case_3():
+    return "b_banana"
+
+
+@case(tags=["b"])
+def case_4():
+    return "b"
+
+
+all_cases = get_all_cases(cases=[case_1, case_2, case_3, case_4])
+
+a_cases = get_all_cases(cases=all_cases, has_tag="a")
+b_cases = get_all_cases(cases=all_cases, has_tag="b")
+
+banana_cases = get_all_cases(cases=a_cases + b_cases, has_tag=["banana"])
+
+
+@parametrize_with_cases("word", cases=all_cases)
+def test_all(word):
+    assert word in ["a", "a_banana", "b", "b_banana"]
+
+
+@parametrize_with_cases("word", cases=a_cases)
+def test_a(word):
+    assert "a" in word
+
+
+@parametrize_with_cases("word", cases=b_cases)
+def test_b(word):
+    assert "b" in word
+
+
+@parametrize_with_cases("word", cases=banana_cases)
+def test_banana(word):
+    assert "banana" in word
+
+
+def test_get_cases_without_parametrization_target():
+    assert len(list(all_cases)) == 4
+    assert len(list(a_cases)) == 2
+    assert len(list(b_cases)) == 2
+    assert len(list(banana_cases)) == 2


### PR DESCRIPTION
Ref #258 

For collecting cases without specifying a target, this PR extends `get_all_cases` to **optionally** take a `parametrization_target` to allow for filtering cases which are explicitly given using `get_all_cases(cases=[case_1, case_2, ...])`.

This PR also enabled direct module references to be given instead of just function references for `parametrization_target` to increase its flexibility when using relative `cases` such as `cases='.'`, `cases=AUTO`. This enables things like

#### Retrieve cases for test modules
```python
# Get all cases from cases_xyz.py or test_xyz_cases.py
import test.test_xyz
xyz_cases = get_all_cases(test.test_xyz)
```

#### Filtering
```python
# test/somewhere/xyz/cases.py
@case(tags=["a", "banana"])
def case_1():
    return "a_banana"

@case(tags=["a"])
def case_2():
    return "a"

# test.elsewhere.test_something
import test.somewhere.xyz.cases as xyz_cases 
all_cases = get_all_cases(cases=xyz_cases, has_tag="a")

@parametrize_with_cases("val", cases=xyz_cases, has_tag="banana")
def test_func(val):
    ... # only receives `case_1`
```

## Note
I did not modify `get_paramtrize_args` to extend the functionality there as it was out of scope and the chain of the parameter for the module gets passed through quite a few functions.