### PR TITLE
Fixed `AttributeError`: module 'pytest_cases' has no attribute 'CasesCollectionWarning' when running `pytest-xdist` and at least one cases class is ignored because of `__init__` or `__new__`. …

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.6.11 - bugfix for pytest-xdist
+
+ - Fixed `AttributeError`: module 'pytest_cases' has no attribute 'CasesCollectionWarning' when running `pytest-xdist` and at least one cases class is ignored because of `__init__` or `__new__`. Fixed [#249](https://github.com/smarie/python-pytest-cases/issues/249).
+
 ### 3.6.10 - bugfix for pytest 7.1
 
  - Fixed `ImportError` when using `pytest 7.1`. Fixed [#264](https://github.com/smarie/python-pytest-cases/issues/264) and [pytest-dev#9762](https://github.com/pytest-dev/pytest/issues/9762).

--- a/src/pytest_cases/__init__.py
+++ b/src/pytest_cases/__init__.py
@@ -12,7 +12,7 @@ from .fixture_parametrize_plus import pytest_parametrize_plus, parametrize_plus,
 from .case_funcs import case, copy_case_info, set_case_id, get_case_id, get_case_marks, \
     get_case_tags, matches_tag_query, is_case_class, is_case_function
 from .case_parametrizer_new import parametrize_with_cases, THIS_MODULE, get_all_cases, get_parametrize_args, \
-    get_current_case_id, get_current_cases, get_current_params
+    get_current_case_id, get_current_cases, get_current_params, CasesCollectionWarning
 
 try:
     # -- Distribution mode --
@@ -55,5 +55,5 @@ __all__ = [
     'get_case_tags', 'matches_tag_query', 'is_case_class', 'is_case_function',
     # test functions
     'get_all_cases', 'parametrize_with_cases', 'THIS_MODULE', 'get_parametrize_args', 'get_current_case_id',
-    'get_current_cases', 'get_current_params'
+    'get_current_cases', 'get_current_params', 'CasesCollectionWarning'
 ]

--- a/src/pytest_cases/case_parametrizer_new.py
+++ b/src/pytest_cases/case_parametrizer_new.py
@@ -683,6 +683,7 @@ class CasesCollectionWarning(UserWarning):
     """
     Warning emitted when pytest cases is not able to collect a file or symbol in a module.
     """
+    # Note: if we change this, then the symbol MUST be present in __init__ for import, see GH#249
     __module__ = "pytest_cases"
 
 


### PR DESCRIPTION
The warning happens when at least one cases class is ignored because of `__init__` or `__new__`.

Fixed #249