### PR TITLE
Fix error with pytest `--strict-markers`

### DIFF
--- a/src/pytest_cases/common_pytest_marks.py
+++ b/src/pytest_cases/common_pytest_marks.py
@@ -292,28 +292,24 @@ def markinfos_to_markdecorators(marks,                # type: Iterable[Mark]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             for m in marks:
-                # create a dummy new MarkDecorator named "MarkDecorator" for reference
-                md = pytest.mark.MarkDecorator()
-
                 if PYTEST3_OR_GREATER:
-                    if isinstance(m, type(md)):
+                    if isinstance(m, MarkDecorator):
                         # already a decorator, we can use it
                         marks_mod.append(m)
                     else:
-                        md.mark = m
+                        md = MarkDecorator(m)
                         marks_mod.append(md)
                 else:
+                    # create a dummy new MarkDecorator named "MarkDecorator" for reference
+                    md = MarkDecorator()
                     # always recreate one, type comparison does not work (all generic stuff)
                     md.name = m.name
-                    # md.markname = m.name
+
                     if function_marks:
                         md.args = m.args  # a mark on a function does not include the function in the args
                     else:
                         md.args = m.args[:-1]  # not a function: the value is in the args, remove it
                     md.kwargs = m.kwargs
-
-                    # markinfodecorator = getattr(pytest.mark, markinfo.name)
-                    # markinfodecorator(*markinfo.args)
 
                     marks_mod.append(md)
 

--- a/tests/pytest_extension/meta/raw/xfail_marker/cmdargs.txt
+++ b/tests/pytest_extension/meta/raw/xfail_marker/cmdargs.txt
@@ -1,0 +1,1 @@
+--strict-markers

--- a/tests/pytest_extension/meta/raw/xfail_marker/xfail_marker.py
+++ b/tests/pytest_extension/meta/raw/xfail_marker/xfail_marker.py
@@ -1,0 +1,16 @@
+# META
+# {'passed': 1, 'xfailed': 1, 'failed': 0}
+# END META
+import pytest
+from pytest_cases import parametrize_with_cases
+
+def case_a():
+    return "a"
+
+@pytest.mark.xfail
+def case_b():
+    raise RuntimeError("Expected to Fail")
+
+@parametrize_with_cases("case", cases=".")
+def test_cases(case):
+    assert case == "a"

--- a/tests/pytest_extension/meta/test_all.py
+++ b/tests/pytest_extension/meta/test_all.py
@@ -6,6 +6,7 @@ import re
 from os.path import join, dirname, isdir, exists
 
 import pytest
+from pytest import __version__
 from pytest_cases.common_mini_six import string_types
 
 # Make the list of all tests that we will have to execute (each in an independent pytest runner)
@@ -19,6 +20,11 @@ META_REGEX = re.compile(
 # )(?P<asserts_dct>.*)(
 # END META)
 .*""")
+
+# Certain tests may use arguments that change name depending on the version
+# of pytest. Here we provide a lookup table to correct the argument
+# { <latest-pytest-arg> : { <major-version> : <major-version-arg> }}
+PYTEST_ARG_LOOKUP = {"--strict-markers": {"3": "--strict"}}
 
 
 @pytest.mark.parametrize('test_to_run', test_files, ids=str)
@@ -165,4 +171,6 @@ def get_pytest_prepare_config(dynamic=False):
 
 
 def process_cmdargs(cmdargs):
-    return shlex.split(cmdargs)
+    # Some provide arguments may need to be converted to their corresponding
+    # spelling depending on the pytest version.
+    return [PYTEST_ARG_LOOKUP.get(x, {}).get(__version__[0], x) for x in shlex.split(cmdargs)]


### PR DESCRIPTION
Fixes: #283 

Proposed fix for the issue where the strict markers mode is enable in pytest. 

I took a slightly different approach to the suggested fix in the issue, but I hope it is alright. 

Any feedback with regards to testing and implementation would be greatly appreciated.