### PR TITLE
Use LooseVersion from looseversion rather than distutils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ setup_requires =
     setuptools_scm
     pytest-runner
 install_requires =
+    looseversion
     decopatch
     makefun>=1.9.5
     # note: pytest, too :)

--- a/src/pytest_cases/common_pytest_marks.py
+++ b/src/pytest_cases/common_pytest_marks.py
@@ -5,7 +5,7 @@
 import itertools
 
 import warnings
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 try:  # python 3.3+
     from inspect import signature

--- a/tests/cases/issues/test_issue_246.py
+++ b/tests/cases/issues/test_issue_246.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 import pytest
 from pytest_cases import parametrize_with_cases


### PR DESCRIPTION
Using pytest-cases in python 3.11 results in a long string of deprecation warnings due to use of distutils.LooseVersion. This patch uses LooseVersion from "looseversion" package, which is designed to be a drop-in replacement without the deprecation warning.