### PR TITLE
Using packaging.version instead of distutils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ setup_requires =
 install_requires =
     decopatch
     makefun>=1.9.5
+    packaging
     # note: pytest, too :)
     functools32;python_version<'3.2'
     # note: do not use double quotes in these, this triggers a weird bug in PyCharm in debug mode only

--- a/src/pytest_cases/common_pytest_marks.py
+++ b/src/pytest_cases/common_pytest_marks.py
@@ -5,7 +5,7 @@
 import itertools
 
 import warnings
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 try:  # python 3.3+
     from inspect import signature
@@ -27,22 +27,22 @@ except ImportError:
 from .common_mini_six import string_types
 
 
-PYTEST_VERSION = LooseVersion(pytest.__version__)
-PYTEST3_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.0.0')
-PYTEST32_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.2.0')
-PYTEST33_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.3.0')
-PYTEST34_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.4.0')
-PYTEST35_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.5.0')
-PYTEST361_36X = LooseVersion('3.6.0') < PYTEST_VERSION < LooseVersion('3.7.0')
-PYTEST37_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.7.0')
-PYTEST38_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.8.0')
-PYTEST46_OR_GREATER = PYTEST_VERSION >= LooseVersion('4.6.0')
-PYTEST53_OR_GREATER = PYTEST_VERSION >= LooseVersion('5.3.0')
-PYTEST54_OR_GREATER = PYTEST_VERSION >= LooseVersion('5.4.0')
-PYTEST421_OR_GREATER = PYTEST_VERSION >= LooseVersion('4.2.1')
-PYTEST6_OR_GREATER = PYTEST_VERSION >= LooseVersion('6.0.0')
-PYTEST7_OR_GREATER = PYTEST_VERSION >= LooseVersion('7.0.0')
-PYTEST71_OR_GREATER = PYTEST_VERSION >= LooseVersion('7.1.0')
+PYTEST_VERSION = Version(pytest.__version__)
+PYTEST3_OR_GREATER = PYTEST_VERSION >= Version('3.0.0')
+PYTEST32_OR_GREATER = PYTEST_VERSION >= Version('3.2.0')
+PYTEST33_OR_GREATER = PYTEST_VERSION >= Version('3.3.0')
+PYTEST34_OR_GREATER = PYTEST_VERSION >= Version('3.4.0')
+PYTEST35_OR_GREATER = PYTEST_VERSION >= Version('3.5.0')
+PYTEST361_36X = Version('3.6.0') < PYTEST_VERSION < Version('3.7.0')
+PYTEST37_OR_GREATER = PYTEST_VERSION >= Version('3.7.0')
+PYTEST38_OR_GREATER = PYTEST_VERSION >= Version('3.8.0')
+PYTEST46_OR_GREATER = PYTEST_VERSION >= Version('4.6.0')
+PYTEST53_OR_GREATER = PYTEST_VERSION >= Version('5.3.0')
+PYTEST54_OR_GREATER = PYTEST_VERSION >= Version('5.4.0')
+PYTEST421_OR_GREATER = PYTEST_VERSION >= Version('4.2.1')
+PYTEST6_OR_GREATER = PYTEST_VERSION >= Version('6.0.0')
+PYTEST7_OR_GREATER = PYTEST_VERSION >= Version('7.0.0')
+PYTEST71_OR_GREATER = PYTEST_VERSION >= Version('7.1.0')
 
 
 def get_param_argnames_as_list(argnames):

--- a/src/pytest_cases/plugin.py
+++ b/src/pytest_cases/plugin.py
@@ -572,7 +572,7 @@ class SuperClosure(MutableSequence):
         all_fixture_defs = self.tree.get_all_fixture_defs(drop_fake_fixtures=False, try_to_sort=True)
 
         # # also sort all partitions (note that we cannot rely on the order in all_fixture_defs when scopes are same!)
-        # if LooseVersion(pytest.__version__) >= LooseVersion('3.5.0'):
+        # if Version(pytest.__version__) >= Version('3.5.0'):
         #     f_scope = get_pytest_function_scopeval()
         #     for p in self.partitions:
         #         def sort_by_scope2(fixture_name):  # noqa

--- a/tests/cases/issues/test_issue_242.py
+++ b/tests/cases/issues/test_issue_242.py
@@ -1,5 +1,5 @@
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import sys
 
@@ -9,8 +9,8 @@ from multiprocessing import Pool, Process
 from functools import partial
 
 
-PYTEST_VERSION = LooseVersion(pytest.__version__)
-PYTEST3_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.0.0')
+PYTEST_VERSION = Version(pytest.__version__)
+PYTEST3_OR_GREATER = PYTEST_VERSION >= Version('3.0.0')
 PY3 = sys.version_info >= (3,)
 
 

--- a/tests/cases/issues/test_issue_246.py
+++ b/tests/cases/issues/test_issue_246.py
@@ -1,10 +1,10 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 from pytest_cases import parametrize_with_cases
 
-PYTEST_VERSION = LooseVersion(pytest.__version__)
-PYTEST3_OR_GREATER = PYTEST_VERSION >= LooseVersion('3.0.0')
+PYTEST_VERSION = Version(pytest.__version__)
+PYTEST3_OR_GREATER = PYTEST_VERSION >= Version('3.0.0')
 
 if PYTEST3_OR_GREATER:
     @pytest.mark.foo


### PR DESCRIPTION
This PR migrates from distutils to packaging.version for comparing versions. This follows the recommendations from the distutils deprecation warnings. Distutils is deprecated, and is removed in the upcoming Python 3.12 (pytest-cases is incompatible with Python 3.12 for this reason).

This is an alternative implementation to PR #303, which uses a replacement of `LooseVersion`. Because this package is simply comparing pytest package versions, which are all PEP 440 compliant, `LooseVersion` is not required, and the more standard `packaging` package is sufficient.  

Closes #297, closes #307  