### PR TITLE
remove use pytest-runner

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ classifiers =
 # one day these will be able to come from requirement files, see https://github.com/pypa/setuptools/issues/1951. But will it be better ?
 setup_requires =
     setuptools_scm
-    pytest-runner
 install_requires =
     decopatch
     makefun>=1.15.1


### PR DESCRIPTION
Remove use pytest-runner because it depends on deprecated features of setuptools.
Look on comment on https://github.com/pytest-dev/pytest-runner/