### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
 
       - name: Install python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.9
           architecture: x64
@@ -57,10 +57,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
 
       - name: Install python ${{ matrix.nox_session.python }} for tests
-        uses: MatteoH2O1999/setup-python@v2  # actions/setup-python@v4
+        uses: MatteoH2O1999/setup-python@v3.0.0  # actions/setup-python@v5.0.0
         id: set-py
         with:
           python-version: ${{ matrix.nox_session.python }}
@@ -69,7 +69,7 @@ jobs:
           cache-build: true
 
       - name: Install python 3.12 for nox
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.12
           architecture: x64
@@ -88,7 +88,7 @@ jobs:
       # Share ./docs/reports so that they can be deployed with doc in next job
       - name: Share reports with other jobs
         # if: matrix.nox_session == '...': not needed, if empty won't be shared
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: reports_dir
           path: ./docs/reports
@@ -98,10 +98,10 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
 
       - name: Install python 3.9 for nox
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.9
           architecture: x64
@@ -123,19 +123,19 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
 
       - name: Checkout with no depth
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0  # so that gh-deploy works
 
       - name: Install python 3.9 for nox
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.9
           architecture: x64
 
       # 1) retrieve the reports generated previously
       - name: Retrieve reports
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4.1.1
         with:
           name: reports_dir
           path: ./docs/reports
@@ -167,7 +167,7 @@ jobs:
           EOF
       - name: \[not on TAG\] Publish coverage report
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads')
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.5
         with:
           files: ./docs/reports/coverage/coverage.xml
 
@@ -181,7 +181,7 @@ jobs:
       # 8) Publish the wheel on PyPi
       - name: \[TAG only\] Deploy on PyPi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.5](https://github.com/codecov/codecov-action/releases/tag/v3.1.5)** on 2024-01-25T18:48:29Z
* **[MatteoH2O1999/setup-python](https://github.com/MatteoH2O1999/setup-python)** published a new release **[v3.0.0](https://github.com/MatteoH2O1999/setup-python/releases/tag/v3.0.0)** on 2023-12-13T21:39:29Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.11](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.11)** on 2023-11-29T02:41:33Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)** on 2023-12-06T10:59:28Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.1](https://github.com/actions/download-artifact/releases/tag/v4.1.1)** on 2024-01-10T17:24:44Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.0](https://github.com/actions/upload-artifact/releases/tag/v4.3.0)** on 2024-01-23T17:40:41Z
