### PR TITLE
Fixed `PytestRemovedIn9Warning: Marks applied to fixtures have no effect`.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 3.8.5 - Suppressed annoying warning with pytest 8
+
+- Fixed `PytestRemovedIn9Warning: Marks applied to fixtures have no effect`. Fixed
+  [#337](https://github.com/smarie/python-pytest-cases/issues/337)
+
 ### 3.8.4 - Removed debug logs
 
 - Reverted `DEBUG` flag used for pytest 8 compatibility. Fixed

--- a/src/pytest_cases/common_pytest_marks.py
+++ b/src/pytest_cases/common_pytest_marks.py
@@ -201,21 +201,29 @@ def remove_pytest_mark(f, mark_name):
     return f
 
 
-def get_pytest_parametrize_marks(f):
+def get_pytest_parametrize_marks(
+    f,
+    pop=False  # type: bool
+):
     """
     Returns the @pytest.mark.parametrize marks associated with a function (and only those)
 
     :param f:
+    :param pop: boolean flag, when True the marks will be removed from f.
     :return: a tuple containing all 'parametrize' marks
     """
     # pytest > 3.2.0
     marks = getattr(f, 'pytestmark', None)
     if marks is not None:
+        if pop:
+            delattr(f, 'pytestmark')
         return tuple(_ParametrizationMark(m) for m in marks if m.name == 'parametrize')
     else:
         # older versions
         mark_info = getattr(f, 'parametrize', None)
         if mark_info is not None:
+            if pop:
+                delattr(f, 'parametrize')
             # mark_info.args contains a list of (name, values)
             if len(mark_info.args) % 2 != 0:
                 raise ValueError("internal pytest compatibility error - please report")

--- a/src/pytest_cases/fixture_core2.py
+++ b/src/pytest_cases/fixture_core2.py
@@ -40,7 +40,7 @@ except ImportError:
 from .common_pytest_lazy_values import get_lazy_args
 from .common_pytest import get_pytest_parametrize_marks, make_marked_parameter_value, get_param_argnames_as_list, \
     combine_ids, is_marked_parameter_value, pytest_fixture, resolve_ids, extract_parameterset_info, make_test_ids
-from .common_pytest_marks import PYTEST3_OR_GREATER
+from .common_pytest_marks import PYTEST3_OR_GREATER, PYTEST8_OR_GREATER
 from .fixture__creation import get_caller_module, check_name_available, WARN, CHANGE
 from .fixture_core1_unions import ignore_unused, is_used_request, NOT_USED, _make_unpack_fixture
 
@@ -423,7 +423,7 @@ def _decorate_fixture_plus(fixture_func,
         _make_unpack_fixture(caller_module, unpack_into, name, hook=hook, in_cls=False)
 
     # (1) Collect all @pytest.mark.parametrize markers (including those created by usage of @cases_data)
-    parametrizer_marks = get_pytest_parametrize_marks(fixture_func)
+    parametrizer_marks = get_pytest_parametrize_marks(fixture_func, pop=PYTEST8_OR_GREATER)
     if len(parametrizer_marks) < 1:
         # make the fixture union-aware
         wrapped_fixture_func = ignore_unused(fixture_func)


### PR DESCRIPTION
Fixed #337