### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.6
 
       - name: Install python 3.9
         uses: actions/setup-python@v5.1.0
@@ -57,10 +57,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.6
 
       - name: Install python ${{ matrix.nox_session.python }} for tests
-        uses: MatteoH2O1999/setup-python@v3.2.0  # actions/setup-python@v5.1.0
+        uses: MatteoH2O1999/setup-python@v4.0.0  # actions/setup-python@v5.1.0
         id: set-py
         with:
           python-version: ${{ matrix.nox_session.python }}
@@ -88,7 +88,7 @@ jobs:
       # Share ./docs/reports so that they can be deployed with doc in next job
       - name: Share reports with other jobs
         # if: matrix.nox_session == '...': not needed, if empty won't be shared
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: reports_dir
           path: ./docs/reports
@@ -98,7 +98,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.6
 
       - name: Install python 3.9 for nox
         uses: actions/setup-python@v5.1.0
@@ -123,7 +123,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
 
       - name: Checkout with no depth
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0  # so that gh-deploy works
 
@@ -135,7 +135,7 @@ jobs:
 
       # 1) retrieve the reports generated previously
       - name: Retrieve reports
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4.1.7
         with:
           name: reports_dir
           path: ./docs/reports
@@ -167,7 +167,7 @@ jobs:
           EOF
       - name: \[not on TAG\] Publish coverage report
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads')
-        uses: codecov/codecov-action@v4.1.1
+        uses: codecov/codecov-action@v4.4.1
         with:
           files: ./docs/reports/coverage/coverage.xml
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.6](https://github.com/actions/checkout/releases/tag/v4.1.6)** on 2024-05-16T18:11:28Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.3](https://github.com/actions/upload-artifact/releases/tag/v4.3.3)** on 2024-04-22T16:21:25Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.4.1](https://github.com/codecov/codecov-action/releases/tag/v4.4.1)** on 2024-05-20T14:11:05Z
* **[MatteoH2O1999/setup-python](https://github.com/MatteoH2O1999/setup-python)** published a new release **[v4.0.0](https://github.com/MatteoH2O1999/setup-python/releases/tag/v4.0.0)** on 2024-05-21T19:07:31Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.7](https://github.com/actions/download-artifact/releases/tag/v4.1.7)** on 2024-04-24T14:48:32Z
