### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.2.2
 
       - name: Install python 3.9
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.9
           architecture: x64
@@ -57,12 +57,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.2.2
 
         # General case
       - name: Install python ${{ matrix.nox_session.python }} for tests (not 3.5 not 3.13)
         if: ${{ ! contains(fromJson('["3.5", "3.13"]'), matrix.nox_session.python ) }}
-        uses: MatteoH2O1999/setup-python@v4  # actions/setup-python@v5.0.0
+        uses: MatteoH2O1999/setup-python@v4.1.1  # actions/setup-python@v5.0.0
         id: set-py
         with:
           python-version: ${{ matrix.nox_session.python }}
@@ -73,7 +73,7 @@ jobs:
         # Particular case of issue with 3.5
       - name: Install python ${{ matrix.nox_session.python }} for tests (3.5)
         if: contains(fromJson('["3.5"]'), matrix.nox_session.python )
-        uses: MatteoH2O1999/setup-python@v4  # actions/setup-python@v5.0.0
+        uses: MatteoH2O1999/setup-python@v4.1.1  # actions/setup-python@v5.0.0
         id: set-py-35
         with:
           python-version: ${{ matrix.nox_session.python }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install python ${{ matrix.nox_session.python }} for tests (3.13)
         if: contains(fromJson('["3.13"]'), matrix.nox_session.python )
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         id: set-py-latest
         with:
           # Include all versions including pre releases
@@ -99,7 +99,7 @@ jobs:
           cache-build: true
 
       - name: Install python 3.12 for nox
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.12
           architecture: x64
@@ -118,7 +118,7 @@ jobs:
       # Share ./docs/reports so that they can be deployed with doc in next job
       - name: Share reports with other jobs
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: reports_dir
           path: ./docs/reports
@@ -128,10 +128,10 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.2.2
 
       - name: Install python 3.9 for nox
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.9
           architecture: x64
@@ -153,19 +153,19 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
 
       - name: Checkout with no depth
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0  # so that gh-deploy works
 
       - name: Install python 3.9 for nox
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.9
           architecture: x64
 
       # 1) retrieve the reports generated previously
       - name: Retrieve reports
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: reports_dir
           path: ./docs/reports
@@ -197,7 +197,7 @@ jobs:
           EOF
       - name: \[not on TAG\] Publish coverage report
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads')
-        uses: codecov/codecov-action@v4.1.1
+        uses: codecov/codecov-action@v4.6.0
         with:
           files: ./docs/reports/coverage/coverage.xml
       - name: \[not on TAG\] Build wheel and sdist
@@ -214,7 +214,7 @@ jobs:
       # 8) Publish the wheel on PyPi
       - name: \[TAG only\] Deploy on PyPi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.11.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.3](https://github.com/actions/upload-artifact/releases/tag/v4.4.3)** on 2024-10-09T17:17:34Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.11.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0)** on 2024-10-30T01:46:00Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.3.0](https://github.com/actions/setup-python/releases/tag/v5.3.0)** on 2024-10-24T14:15:17Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.8](https://github.com/actions/download-artifact/releases/tag/v4.1.8)** on 2024-07-05T15:12:41Z
* **[MatteoH2O1999/setup-python](https://github.com/MatteoH2O1999/setup-python)** published a new release **[v4.1.1](https://github.com/MatteoH2O1999/setup-python/releases/tag/v4.1.1)** on 2024-10-15T14:55:14Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.6.0](https://github.com/codecov/codecov-action/releases/tag/v4.6.0)** on 2024-10-01T14:53:02Z
