### PR TITLE
Fix collection issue in Pytest 9 with overridden fixtures

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,12 @@
 # Changelog
 
-### 3.10.0 - (in progress) New `with_case_tags` decorator
+### 3.10.0 - (in progress) New `with_case_tags` decorator + pytest 9 compatibility
 
+- Fixed an issue with `pytest 9` related to the fixture closure building fixes
+  [pytest-dev/pytest#13789](https://github.com/pytest-dev/pytest/pull/13789),
+  solving [pytest-dev/pytest#13773](https://github.com/pytest-dev/pytest/issues/13773).
+  Fixed [#374](https://github.com/smarie/python-pytest-cases/issues/374). PR
+  [#376](https://github.com/smarie/python-pytest-cases/pull/376) by [jammer87](https://github.com/jammer87).
 - Added the `with_case_tags` decorator for applying common tags to all cases
   defined in a case class. Fixes [#351](https://github.com/smarie/python-pytest-cases/issues/351).
   PR [#361](https://github.com/smarie/python-pytest-cases/pull/361)

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,26 +53,32 @@ class Folders:
 ENVS = {
     # python 3.14
     (PY314, "pytest-latest"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": ""}},
+    (PY314, "pytest8.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<9"}},
     (PY314, "pytest7.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<8"}},
     (PY314, "pytest6.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<7"}},
     # python 3.13
     (PY313, "pytest-latest"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": ""}},
+    (PY313, "pytest8.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<9"}},
     (PY313, "pytest7.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<8"}},
     (PY313, "pytest6.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<7"}},
     # python 3.12
     (PY312, "pytest-latest"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": ""}},
+    (PY312, "pytest8.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<9"}},
     (PY312, "pytest7.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<8"}},
     (PY312, "pytest6.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<7"}},
     # python 3.11
     # We'll run 'pytest-latest' this last for coverage
+    (PY311, "pytest8.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<9"}},
     (PY311, "pytest7.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<8"}},
     (PY311, "pytest6.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<7"}},
     # python 3.10
     (PY310, "pytest-latest"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": ""}},
+    (PY310, "pytest8.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<9"}},
     (PY310, "pytest7.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<8"}},
     (PY310, "pytest6.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<7"}},
     # python 3.9
     (PY39, "pytest-latest"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": ""}},
+    (PY39, "pytest8.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<9"}},
     (PY39, "pytest7.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<8"}},
     (PY39, "pytest6.x"): {"coverage": False, "pkg_specs": {"pip": ">19", "pytest": "<7"}},
     # IMPORTANT: this should be last so that the folder docs/reports is not deleted afterwards

--- a/src/pytest_cases/common_pytest_marks.py
+++ b/src/pytest_cases/common_pytest_marks.py
@@ -46,6 +46,7 @@ PYTEST71_OR_GREATER = PYTEST_VERSION >= Version('7.1.0')
 PYTEST8_OR_GREATER = PYTEST_VERSION >= Version('8.0.0')
 PYTEST81_OR_GREATER = PYTEST_VERSION >= Version('8.1.0')
 PYTEST84_OR_GREATER = PYTEST_VERSION >= Version('8.4.0')
+PYTEST9_OR_GREATER = PYTEST_VERSION >= Version('9.0.0')
 
 
 def get_param_argnames_as_list(argnames):

--- a/src/pytest_cases/plugin.py
+++ b/src/pytest_cases/plugin.py
@@ -28,7 +28,8 @@ except ImportError:
 
 from .common_mini_six import string_types
 from .common_pytest_lazy_values import get_lazy_args
-from .common_pytest_marks import PYTEST35_OR_GREATER, PYTEST46_OR_GREATER, PYTEST37_OR_GREATER, PYTEST7_OR_GREATER, PYTEST8_OR_GREATER
+from .common_pytest_marks import PYTEST35_OR_GREATER, PYTEST46_OR_GREATER, PYTEST37_OR_GREATER, PYTEST7_OR_GREATER, \
+    PYTEST8_OR_GREATER, PYTEST9_OR_GREATER
 from .common_pytest import get_pytest_nodeid, get_pytest_function_scopeval, is_function_node, get_param_names, \
     get_param_argnames_as_list, has_function_scope, set_callspec_arg_scope_to_function, in_callspec_explicit_args
 
@@ -334,8 +335,19 @@ class FixtureClosureNode(object):
                     # normal fixture
                     self.add_required_fixture(fixname, fixturedefs)
 
-                    # add all dependencies in the to do list
-                    dependencies = _fixdef.argnames
+                    # add all dependencies in the to the list, accounting for overrides
+                    if PYTEST9_OR_GREATER:
+                        dependencies_set = set()
+                        for _fixture_or_overridden in reversed(fixturedefs):
+                            dependencies_set.update(_fixture_or_overridden.argnames)
+                            # If there's an override and doesn't depend on the overridden fixture,
+                            # ignore remaining definitions
+                            if fixname not in _fixture_or_overridden.argnames:
+                                break
+                        dependencies = list(dependencies_set)
+                    else:
+                        dependencies = _fixdef.argnames
+
                     # - append: was pytest default
                     # pending_fixture_names += dependencies
                     # - prepend: makes much more sense

--- a/src/pytest_cases/plugin.py
+++ b/src/pytest_cases/plugin.py
@@ -337,14 +337,13 @@ class FixtureClosureNode(object):
 
                     # add all dependencies, accounting for overrides
                     if PYTEST9_OR_GREATER:
-                        dependencies_set = set()
+                        dependencies = []
                         for _fixture_or_overridden in reversed(fixturedefs):
-                            dependencies_set.update(_fixture_or_overridden.argnames)
+                            dependencies = list(_fixture_or_overridden.argnames) + dependencies
                             # If there's an override and doesn't depend on the overridden fixture,
                             # ignore remaining definitions
                             if fixname not in _fixture_or_overridden.argnames:
                                 break
-                        dependencies = list(dependencies_set)
                     else:
                         dependencies = _fixdef.argnames
 

--- a/src/pytest_cases/plugin.py
+++ b/src/pytest_cases/plugin.py
@@ -335,7 +335,7 @@ class FixtureClosureNode(object):
                     # normal fixture
                     self.add_required_fixture(fixname, fixturedefs)
 
-                    # add all dependencies in the to the list, accounting for overrides
+                    # add all dependencies, accounting for overrides
                     if PYTEST9_OR_GREATER:
                         dependencies_set = set()
                         for _fixture_or_overridden in reversed(fixturedefs):

--- a/tests/cases/issues/test_issue_374.py
+++ b/tests/cases/issues/test_issue_374.py
@@ -32,7 +32,7 @@ class TestOverrideWithoutParent:
 
 def test_overridden_fixtures(pytester):
     pytester.makepyfile(OVERRIDDEN_FIXTURES_TEST_FILE)
-    result = pytester.runpytest("-p", "pytest_cases.plugin")
+    result = pytester.runpytest()
     result.assert_outcomes(passed=2)
 
 
@@ -87,5 +87,5 @@ class TestOverrideWithoutParent:
 
 def test_overridden_unions(pytester):
     pytester.makepyfile(OVERRIDDEN_UNION_FIXTURES_TEST_FILE)
-    result = pytester.runpytest("-p", "pytest_cases.plugin")
+    result = pytester.runpytest()
     result.assert_outcomes(passed=6)

--- a/tests/cases/issues/test_issue_374.py
+++ b/tests/cases/issues/test_issue_374.py
@@ -1,0 +1,91 @@
+OVERRIDDEN_FIXTURES_TEST_FILE = """
+import pytest
+
+@pytest.fixture
+def db(): pass
+
+@pytest.fixture
+def app(db): pass
+
+
+# See https://github.com/pytest-dev/pytest/issues/13773
+# Issue occurred in collection with Pytest 9+
+
+    
+class TestOverrideWithParent:
+    # Overrides module-level app, doesn't request `db` directly, only transitively.
+    @pytest.fixture
+    def app(self, app): pass
+
+    def test_something(self, app): pass
+
+
+
+class TestOverrideWithoutParent:
+    # Overrides module-level app, doesn't request `db` at all.
+    @pytest.fixture
+    def app(self): pass
+
+    def test_something(self, app): pass
+"""
+
+
+def test_overridden_fixtures(pytester):
+    pytester.makepyfile(OVERRIDDEN_FIXTURES_TEST_FILE)
+    result = pytester.runpytest("-p", "pytest_cases.plugin")
+    result.assert_outcomes(passed=2)
+
+
+# Using union fixtures.
+OVERRIDDEN_UNION_FIXTURES_TEST_FILE = """
+import pytest
+from pytest_cases import parametrize, parametrize_with_cases, case, fixture
+
+@fixture
+def db(): pass
+
+@fixture
+def app(db): pass
+
+def case_hello():
+    return "hello !"
+
+@fixture
+def surname():
+    return "joe"
+
+@fixture
+@parametrize("_name", ["you", "earthling"])
+def name(_name, surname, app):
+    return f"{_name} {surname}"
+
+@case(id="hello_fixture")
+def case_basic3(name):
+    return "hello, %s !" % name
+
+
+class TestOverrideWithParent:
+    # Overrides module-level name, doesn't request `name` directly, only transitively.
+    @fixture
+    def name(self, name):
+        return "overridden %s" % name
+
+    @parametrize_with_cases("msg", cases=".")
+    def test_something(self, msg): pass
+
+class TestOverrideWithoutParent:
+    # Overrides module-level name, doesn't request name at all
+    @fixture
+    @parametrize("_name", ["hi", "martian"])
+    def name(self, _name):
+        return _name
+
+    @parametrize_with_cases("msg", cases=".")
+    def test_something(self, msg): pass
+"""
+
+
+def test_overridden_unions(pytester):
+    pytester.makepyfile(OVERRIDDEN_UNION_FIXTURES_TEST_FILE)
+    result = pytester.runpytest("-p", "pytest_cases.plugin")
+    result.assert_outcomes(passed=6)


### PR DESCRIPTION
Addresses #374 which was introduced by the pytest fixes for https://github.com/pytest-dev/pytest/issues/13773

@smarie feel free to close/take over as part of larger Pytest 9 support.

If you want a single PR with #376, #377, #378, #379, #380 with merge conflicts fixed, you can create a new one from https://github.com/jammer87/python-pytest-cases/tree/all-my-merges